### PR TITLE
Authenticate image URLs before using data for templating

### DIFF
--- a/js/layout-javascript/feed-comments-code.js
+++ b/js/layout-javascript/feed-comments-code.js
@@ -640,6 +640,16 @@ DynamicList.prototype.initialize = function() {
             records[i].data['Date'] = moment(obj.data['Date']).utc().format("MMM DD YYYY");
           }
 
+          // Add authentication for images
+          if (obj.data['Image']) {
+            obj.data['Image'] = Fliplet.Media.authenticate(obj.data['Image']);
+          }
+
+          // Add authentication for images in content
+          if (obj.data['Content']) {
+            obj.data['Content'] = Fliplet.Media.authenticate(obj.data['Content']);
+          }
+
           // Add likes flag
           if (_this.data.social && _this.data.social.likes) {
             records[i].likesEnabled = true;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -357,6 +357,16 @@ DynamicList.prototype.initialize = function() {
           records[i].data['Date'] = moment(obj.data['Date']).utc().format("MMM DD YYYY");
         }
 
+        // Add authentication for images
+        if (obj.data['Image']) {
+          obj.data['Image'] = Fliplet.Media.authenticate(obj.data['Image']);
+        }
+
+        // Add authentication for images in content
+        if (obj.data['Content']) {
+          obj.data['Content'] = Fliplet.Media.authenticate(obj.data['Content']);
+        }
+
         // Add likes flag
         if (_this.data.social && _this.data.social.likes) {
           records[i].likesEnabled = true;

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -458,6 +458,9 @@ DynamicList.prototype.renderLoopHTML = function(records) {
   var modifiedData = _this.convertCategories(records);
 
   modifiedData.forEach(function(obj, index) {
+    if (modifiedData[index].data['Image']) {
+      modifiedData[index].data['Image'] = Fliplet.Media.authenticate(modifiedData[index].data['Image']);
+    }
     modifiedData[index].data.profileHTML = _this.profileHTML(modifiedData[index]);
   });
 

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -354,6 +354,9 @@ DynamicList.prototype.renderLoopHTML = function(records) {
   var _this = this;
 
   records.forEach(function(obj, index) {
+    if (records[index].data.Image) {
+      records[index].data.Image = Fliplet.Media.authenticate(records[index].data.Image);
+    }
     records[index].data.profileHTML = _this.profileHTML(records[index]);
   });
 


### PR DESCRIPTION
To ensure images are correctly rendered for encrypted files, this adds authentication tokens to image URLs before they are used for templating.

Ref. https://github.com/Fliplet/fliplet-studio/issues/2877