### PR TITLE
Ensures lists across agenda dates are aligned to the top

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -200,6 +200,7 @@
   width: 100vw;
   height: 100%;
   overflow: auto;
+  vertical-align: top;
 }
 
 .fl-with-top-menu .new-agenda-list-container .agenda-list-day-holder {


### PR DESCRIPTION
Fixes the following problem

![simulator screen shot - iphone x - 2018-10-10 at 15 41 11](https://user-images.githubusercontent.com/290733/46744383-fad79200-cca2-11e8-8cdc-4cf2981e466a.png)

If there are LFD instances where custom CSS has been activated, use the following custom CSS to fix the issue:

```css
.new-agenda-list-container .agenda-list-day-holder {
  vertical-align: top;
}
```