### PR TITLE
Alert modal after closing data overlay

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -480,6 +480,33 @@ var DynamicLists = (function() {
       Fliplet.Studio.onMessage(function(event) {
         if (event.data && event.data.event === 'overlay-close' && event.data.data && event.data.data.dataSourceId) {
           _this.reloadDataSources().then(function(dataSources) {
+            if (!_this.config.dataAlertSeen) {
+              return Fliplet.Modal.confirm({
+                title: 'Data changes',
+                message: 'If you have updated the column names of your data table, please ensure that all your settings are selecting the right fields.',
+                buttons: {
+                  confirm: {
+                    label: 'OK',
+                    className: 'btn-primary'
+                  },
+                  cancel: {
+                    label: 'Don\'t show this again',
+                    className: 'btn-secondary'
+                  }
+                }
+              }).then(function (result) {
+                if (!result) {
+                  _this.config.dataAlertSeen = true;
+                }
+                
+                allDataSources = dataSources;
+                _this.getColumns(_this.config.dataSourceId);
+                _this.initSelect2(allDataSources);
+                _this.initSecondSelect2(allDataSources);
+                Fliplet.Studio.emit('reload-widget-instance', _this.widgetId);
+              });
+            }
+
             allDataSources = dataSources;
             _this.getColumns(_this.config.dataSourceId);
             _this.initSelect2(allDataSources);
@@ -589,6 +616,7 @@ var DynamicLists = (function() {
           .then(function() {
             // Load sort options
             var dataSourceColumns = dataSourceColumns || _this.config.dataSourceColumns || _this.config.defaultColumns;
+            $sortAccordionContainer.empty();
             _.forEach(_this.config.sortOptions, function(item) {
               item.fromLoading = true; // Flag to close accordions
               item.columns = dataSourceColumns
@@ -600,6 +628,7 @@ var DynamicLists = (function() {
             _this.checkSortPanelLength();
 
             // Load filter options
+            $filterAccordionContainer.empty();
             _.forEach(_this.config.filterOptions, function(item) {
               item.fromLoading = true; // Flag to close accordions
               item.columns = dataSourceColumns;
@@ -688,6 +717,7 @@ var DynamicLists = (function() {
             $('#select_field_link').val(_this.config.summaryLinkAction && _this.config.summaryLinkAction.column || 'none');
             $('#select_type_link').val(_this.config.summaryLinkAction && _this.config.summaryLinkAction.type || 'url');
 
+            $summaryRowContainer.empty();
             _.forEach(_this.config['summary-fields'], function(item) {
               // Backwards compatability
               if (typeof item.interfaceName === 'undefined') {
@@ -763,6 +793,7 @@ var DynamicLists = (function() {
               });
             }
 
+            $detailsRowContainer.empty();
             _.forEach(_this.config.detailViewOptions, function(item) {  
               item.columns = dataSourceColumns;
               _this.addDetailItem(item);


### PR DESCRIPTION
Reference of issue: https://github.com/Fliplet/fliplet-studio/issues/3439

An alert will be shown when a user saves or closes a data table overlay. The alert will notify users that if they changed column names, they have to confirm they still have the right fields selected.