### PR TITLE
Added optimizations to layouts.

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -53,6 +53,12 @@ var DynamicList = function(id, data, container) {
   this.pvPreFilterQuery;
   this.pvOpenQuery;
 
+  /**
+   * this specifies the batch size to be used when rendering in chunks
+   */
+  this.INCREMENTAL_RENDERING_BATCH_SIZE = 100;
+
+
   this.detailHTML = this.data.advancedSettings && this.data.advancedSettings.detailHTML
   ? Handlebars.compile(this.data.advancedSettings.detailHTML)
   : Handlebars.compile(Fliplet.Widget.Templates[_this.agendaLayoutMapping[this.data.layout]['detail']]());
@@ -536,15 +542,13 @@ DynamicList.prototype.filterRecords = function(records, filters) {
 
 DynamicList.prototype.prepareData = function(records) {
   var _this = this;
-  var sorted;
-  var ordered;
   var filtered;
 
   // Prepare sorting
   if (_this.data.sortOptions.length) {
     var fields = [];
     var sortOrder = [];
-    var columns = [];
+    var sortColumns = [];
 
     _this.data.sortOptions.forEach(function(option) {
       fields.push({
@@ -587,17 +591,17 @@ DynamicList.prototype.prepareData = function(records) {
           record.data['modified_' + field.column] = record.data['modified_' + field.column];
         }
 
-        columns.push('data[modified_' + field.column + ']');
       });
 
       return record;
     });
 
-    // Sort data
-    sorted = _.sortBy(mappedRecords, columns);
-    ordered = _.orderBy(sorted, columns, sortOrder);
 
-    records = ordered;
+    sortColumns = fields.map(function (field) {
+      return 'data[modified_' + field.column + ']';
+    })
+    // Sort data
+    records = _.orderBy(mappedRecords, sortColumns, sortOrder);
   }
 
   // Prepare filtering
@@ -902,50 +906,45 @@ DynamicList.prototype.prepareToRenderLoop = function(rows) {
       }
     });
 
-    loopData.push(newObject);
-  });
-
-  // Define detail view data based on user's settings
-  var detailData = [];
-
-  dynamicData.forEach(function(obj) {
-    clonedRecords.some(function(entryData) {
+    dynamicData.forEach(function(dynamicDataObj) {
       var label = '';
       var labelEnabled = true;
       var content = '';
 
       // Define label
-      if (obj.fieldLabel === 'column-name' && obj.column !== 'custom') {
-        label = obj.column;
+      if (dynamicDataObj.fieldLabel === 'column-name' && dynamicDataObj.column !== 'custom') {
+        label = dynamicDataObj.column;
       }
-      if (obj.fieldLabel === 'custom-label') {
-        label = Handlebars.compile(obj.customFieldLabel)(entryData.data);
+      if (dynamicDataObj.fieldLabel === 'custom-label') {
+        label = Handlebars.compile(dynamicDataObj.customFieldLabel)(entry.data);
       }
-      if (obj.fieldLabel === 'no-label') {
+      if (dynamicDataObj.fieldLabel === 'no-label') {
         labelEnabled = false;
       }
       // Define content
-      if (obj.customFieldEnabled) {
-        content = Handlebars.compile(obj.customField)(entryData.data);
+      if (dynamicDataObj.customFieldEnabled) {
+        content = Handlebars.compile(dynamicDataObj.customField)(entry.data);
       } else {
-        content = entryData.data[obj.column];
+        content = entry.data[dynamicDataObj.column];
       }
       // Define data object
-      var newObject = {
-        id: entryData.id,
+      var newEntryDetail = {
+        id: entry.id,
         content: content,
         label: label,
         labelEnabled: labelEnabled,
-        type: obj.type
+        type: dynamicDataObj.type
       }
-
-      var matchingEntry = _.find(loopData, function(entry) {
-        return entry.id === newObject.id;
-      });
-      matchingEntry.entryDetails.push(newObject);
-      savedColumns.push(obj.column);
-    });
+      newObject.entryDetails.push(newEntryDetail);
   });
+    loopData.push(newObject);
+  });
+
+  // Define detail view data based on user's settings
+
+  savedColumns = dynamicData.map(function(data){ 
+    return data.column;
+  })
 
   // Converts date format
   loopData.forEach(function(obj, index) {
@@ -982,14 +981,36 @@ DynamicList.prototype.prepareToRenderLoop = function(rows) {
   _this.modifiedRecords = newRecords;
 }
 
-DynamicList.prototype.renderLoopHTML = function() {
+DynamicList.prototype.renderLoopHTML = function(records) {
   // Function that renders the List template
   var _this = this;
-  var template = _this.data.advancedSettings && _this.data.advancedSettings.loopHTML
-  ? Handlebars.compile(_this.data.advancedSettings.loopHTML)
-  : Handlebars.compile(Fliplet.Widget.Templates[_this.agendaLayoutMapping[_this.data.layout]['loop']]());
 
-  _this.$container.find('#agenda-cards-wrapper-' + _this.data.id + ' .agenda-list-holder').html(template(_this.modifiedRecords));
+
+  var template = _this.data.advancedSettings && _this.data.advancedSettings.loopHTML
+    ? Handlebars.compile(_this.data.advancedSettings.loopHTML)
+    : Handlebars.compile(Fliplet.Widget.Templates[_this.agendaLayoutMapping[_this.data.layout]['loop']]());
+
+  if (_this.data.enabledLimitEntries && _this.data.limitEntries >= 0 && !_this.isSearching && !_this.isFiltering) {
+    limitedList = _this.modifiedListItems.slice(0, _this.data.limitEntries);
+  }
+  _this.$container.find('#agenda-cards-wrapper-' + _this.data.id + ' .agenda-list-holder').empty();
+
+  var renderLoopIndex = 0;
+  function render() {
+    // get the next batch of items to render
+    let nextBatch = _this.modifiedRecords.slice(
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE,
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE + _this.INCREMENTAL_RENDERING_BATCH_SIZE
+    );
+    if (nextBatch.length) {
+      _this.$container.find('#agenda-cards-wrapper-' + _this.data.id + ' .agenda-list-holder').append(template(nextBatch));
+      renderLoopIndex++;
+      // if the browser is ready, render
+      requestAnimationFrame(render);
+    }
+  }
+  // start the initial render
+  requestAnimationFrame(render);
 }
 
 DynamicList.prototype.renderDatesHTML = function(rows, index) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -63,6 +63,11 @@ var DynamicList = function(id, data, container) {
   this.pvFilterQuery;
   this.pvPreFilterQuery;
   this.pvOpenQuery;
+  
+  /**
+   * this specifies the batch size to be used when rendering in chunks
+   */
+  this.INCREMENTAL_RENDERING_BATCH_SIZE = 100;
 
   this.data.bookmarksEnabled = _this.data.social.bookmark;
 
@@ -955,7 +960,7 @@ DynamicList.prototype.prepareData = function(records) {
   if (_this.data.sortOptions.length) {
     var fields = [];
     var sortOrder = [];
-    var columns = [];
+    var sortColumns = [];
 
     _this.data.sortOptions.forEach(function(option) {
       fields.push({
@@ -998,17 +1003,17 @@ DynamicList.prototype.prepareData = function(records) {
           record.data['modified_' + field.column] = record.data['modified_' + field.column];
         }
 
-        columns.push('data[modified_' + field.column + ']');
       });
 
       return record;
     });
 
-    // Sort data
-    sorted = _.sortBy(mappedRecords, columns);
-    ordered = _.orderBy(sorted, columns, sortOrder);
 
-    records = ordered;
+    sortColumns = fields.map(function (field) {
+      return 'data[modified_' + field.column + ']';
+    })
+    // Sort data
+    records = _.orderBy(mappedRecords, sortColumns, sortOrder);
   }
 
   // Prepare filtering
@@ -1391,7 +1396,7 @@ DynamicList.prototype.prepareToRenderLoop = function(records) {
       entryDetails: [],
       originalData: entry.data
     };
-    _this.data['summary-fields'].some(function(obj) {
+    _this.data['summary-fields'].forEach(function(obj) {
       var content = '';
       if (obj.column === 'custom') {
         content = Handlebars.compile(obj.customField)(entry.data)
@@ -1400,51 +1405,45 @@ DynamicList.prototype.prepareToRenderLoop = function(records) {
       }
       newObject[obj.location] = content;
     });
-    loopData.push(newObject);
-  });
 
-  
-  // Define detail view data based on user's settings
-  var detailData = [];
-
-  _this.data.detailViewOptions.forEach(function(obj) {
-    modifiedData.some(function(entryData) {
+    _this.data.detailViewOptions.forEach(function(dynamicDataObj) {
       var label = '';
       var labelEnabled = true;
       var content = '';
 
       // Define label
-      if (obj.fieldLabel === 'column-name' && obj.column !== 'custom') {
-        label = obj.column;
+      if (dynamicDataObj.fieldLabel === 'column-name' && dynamicDataObj.column !== 'custom') {
+        label = dynamicDataObj.column;
       }
-      if (obj.fieldLabel === 'custom-label') {
-        label = Handlebars.compile(obj.customFieldLabel)(entryData.data);
+      if (dynamicDataObj.fieldLabel === 'custom-label') {
+        label = Handlebars.compile(dynamicDataObj.customFieldLabel)(entry.data);
       }
-      if (obj.fieldLabel === 'no-label') {
+      if (dynamicDataObj.fieldLabel === 'no-label') {
         labelEnabled = false;
       }
       // Define content
-      if (obj.customFieldEnabled) {
-        content = Handlebars.compile(obj.customField)(entryData.data);
+      if (dynamicDataObj.customFieldEnabled) {
+        content = Handlebars.compile(dynamicDataObj.customField)(entry.data);
       } else {
-        content = entryData.data[obj.column];
+        content = entry.data[dynamicDataObj.column];
       }
       // Define data object
-      var newObject = {
-        id: entryData.id,
+      var newEntryDetail = {
+        id: dynamicDataObj.id,
         content: content,
         label: label,
         labelEnabled: labelEnabled,
-        type: obj.type
+        type: dynamicDataObj.type
       }
 
-      var matchingEntry = _.find(loopData, function(entry) {
-        return entry.id === newObject.id;
-      });
-      matchingEntry.entryDetails.push(newObject);
-      savedColumns.push(obj.column);
+      newObject.entryDetails.push(newEntryDetail);
     });
+    loopData.push(newObject);
   });
+
+  savedColumns = _this.data.detailViewOptions.map(function(data){ 
+    return data.column;
+  })
 
   if (_this.data.detailViewAutoUpdate) {
     loopData.forEach(function(entry, index) {
@@ -1472,9 +1471,11 @@ DynamicList.prototype.prepareToRenderLoop = function(records) {
   _this.modifiedListItems = loopData;
 }
 
-DynamicList.prototype.renderLoopHTML = function() {
+DynamicList.prototype.renderLoopHTML = function(records) {
   // Function that renders the List template
   var _this = this;
+
+
   var template = _this.data.advancedSettings && _this.data.advancedSettings.loopHTML
     ? Handlebars.compile(_this.data.advancedSettings.loopHTML)
     : Handlebars.compile(Fliplet.Widget.Templates[_this.newsFeedLayoutMapping[_this.data.layout]['loop']]());
@@ -1483,8 +1484,25 @@ DynamicList.prototype.renderLoopHTML = function() {
   if (_this.data.enabledLimitEntries && _this.data.limitEntries >= 0 && !_this.isSearching && !_this.isFiltering) {
     limitedList = _this.modifiedListItems.slice(0, _this.data.limitEntries);
   }
+  _this.$container.find('#news-feed-list-wrapper-' + _this.data.id).empty();
 
-  _this.$container.find('#news-feed-list-wrapper-' + _this.data.id).html(template(limitedList || _this.modifiedListItems));
+  var renderLoopIndex = 0;
+  var data = (limitedList || _this.modifiedListItems);
+  function render() {
+    // get the next batch of items to render
+    let nextBatch = data.slice(
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE,
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE + _this.INCREMENTAL_RENDERING_BATCH_SIZE
+    );
+    if (nextBatch.length) {
+      _this.$container.find('#news-feed-list-wrapper-' + _this.data.id).append(template(nextBatch));
+      renderLoopIndex++;
+      // if the browser is ready, render
+      requestAnimationFrame(render);
+    }
+  }
+  // start the initial render
+  requestAnimationFrame(render);
 }
 
 DynamicList.prototype.getAddPermission = function(data) {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -56,6 +56,11 @@ var DynamicList = function(id, data, container) {
   this.pvPreFilterQuery;
   this.pvOpenQuery;
 
+  /**
+   * this specifies the batch size to be used when rendering in chunks
+   */
+  this.INCREMENTAL_RENDERING_BATCH_SIZE = 100;
+
   this.profileHTML = this.data.advancedSettings && this.data.advancedSettings.detailHTML
   ? Handlebars.compile(this.data.advancedSettings.detailHTML)
   : Handlebars.compile(Fliplet.Widget.Templates[_this.layoutMapping[this.data.layout]['detail']]());
@@ -567,15 +572,13 @@ DynamicList.prototype.filterRecords = function(records, filters) {
 
 DynamicList.prototype.prepareData = function(records) {
   var _this = this;
-  var sorted;
-  var ordered;
   var filtered;
 
   // Prepare sorting
   if (_this.data.sortOptions.length) {
     var fields = [];
     var sortOrder = [];
-    var columns = [];
+    var sortColumns = [];
 
     _this.data.sortOptions.forEach(function(option) {
       fields.push({
@@ -618,17 +621,16 @@ DynamicList.prototype.prepareData = function(records) {
           record.data['modified_' + field.column] = record.data['modified_' + field.column];
         }
 
-        columns.push('data[modified_' + field.column + ']');
       });
 
       return record;
     });
 
+    sortColumns = fields.map(function (field) {
+      return 'data[modified_' + field.column + ']';
+    })
     // Sort data
-    sorted = _.sortBy(mappedRecords, columns);
-    ordered = _.orderBy(sorted, columns, sortOrder);
-
-    records = ordered;
+    records = _.orderBy(mappedRecords, sortColumns, sortOrder);
   }
 
   // Prepare filtering
@@ -1048,7 +1050,7 @@ DynamicList.prototype.prepareToRenderLoop = function(records, forProfile) {
       entryDetails: [],
       originalData: entry.data
     };
-    _this.data['summary-fields'].some(function(obj) {
+    _this.data['summary-fields'].forEach(function(obj) {
       var content = '';
       if (obj.column === 'custom') {
         content = Handlebars.compile(obj.customField)(entry.data)
@@ -1058,7 +1060,7 @@ DynamicList.prototype.prepareToRenderLoop = function(records, forProfile) {
       newObject[obj.location] = content;
     });
 
-    notDynamicData.some(function(obj) {
+    notDynamicData.forEach(function(obj) {
       if (!newObject[obj.location]) {
         var content = '';
         if (obj.column === 'custom') {
@@ -1070,53 +1072,48 @@ DynamicList.prototype.prepareToRenderLoop = function(records, forProfile) {
       }
     });
 
-    loopData.push(newObject);
-  });
-
-  // Define detail view data based on user's settings
-  var detailData = [];
-
-  dynamicData.forEach(function(obj) {
-    modifiedData.some(function(entryData) {
+    dynamicData.forEach(function(dynamicDataObj) {
       var label = '';
       var labelEnabled = true;
       var content = '';
 
       // Define label
-      if (obj.fieldLabel === 'column-name' && obj.column !== 'custom') {
-        label = obj.column;
+      if (dynamicDataObj.fieldLabel === 'column-name' && dynamicDataObj.column !== 'custom') {
+        label = dynamicDataObj.column;
       }
-      if (obj.fieldLabel === 'custom-label') {
-        label = Handlebars.compile(obj.customFieldLabel)(entryData.data);
+      if (dynamicDataObj.fieldLabel === 'custom-label') {
+        label = Handlebars.compile(dynamicDataObj.customFieldLabel)(entry.data);
       }
-      if (obj.fieldLabel === 'no-label') {
+      if (dynamicDataObj.fieldLabel === 'no-label') {
         labelEnabled = false;
       }
       // Define content
-      if (obj.customFieldEnabled) {
-        content = Handlebars.compile(obj.customField)(entryData.data);
+      if (dynamicDataObj.customFieldEnabled) {
+        content = Handlebars.compile(dynamicDataObj.customField)(entry.data);
       } else {
-        content = entryData.data[obj.column];
+        content = entry.data[dynamicDataObj.column];
       }
       // Define data object
-      var newObject = {
-        id: entryData.id,
+      var newEntryDetail = {
+        id: dynamicDataObj.id,
         content: content,
         label: label,
         labelEnabled: labelEnabled,
-        type: obj.type
+        type: dynamicDataObj.type
       }
 
-      var matchingEntry = _.find(loopData, function(entry) {
-        return entry.id === newObject.id;
-      });
-      matchingEntry.entryDetails.push(newObject);
-      savedColumns.push(obj.column);
+      newObject.entryDetails.push(newEntryDetail);
     });
+    loopData.push(newObject);
   });
 
-  loopData.forEach(function(obj, index) {
-    if (_this.data.detailViewAutoUpdate) {
+
+  savedColumns = dynamicData.map(function(data){ 
+    return data.column;
+  })
+  
+  if (_this.data.detailViewAutoUpdate) {
+    loopData.forEach(function(obj, index) {
       var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
       if (extraColumns && extraColumns.length) {
 
@@ -1136,8 +1133,8 @@ DynamicList.prototype.prepareToRenderLoop = function(records, forProfile) {
           obj.entryDetails.push(newColumnData);
         });
       }
-    }
-  });
+    });
+  }
 
   if (forProfile) {
     return loopData;
@@ -1151,7 +1148,7 @@ DynamicList.prototype.renderLoopHTML = function(records) {
   // Function that renders the List template
   var _this = this;
 
-  
+
   var template = _this.data.advancedSettings && _this.data.advancedSettings.loopHTML
     ? Handlebars.compile(_this.data.advancedSettings.loopHTML)
     : Handlebars.compile(Fliplet.Widget.Templates[_this.layoutMapping[_this.data.layout]['loop']]());
@@ -1160,8 +1157,25 @@ DynamicList.prototype.renderLoopHTML = function(records) {
   if (_this.data.enabledLimitEntries && _this.data.limitEntries >= 0 && !_this.isSearching && !_this.isFiltering) {
     limitedList = _this.modifiedListItems.slice(0, _this.data.limitEntries);
   }
+  _this.$container.find('#small-card-list-wrapper-' + _this.data.id).empty();
 
-  _this.$container.find('#small-card-list-wrapper-' + _this.data.id).html(template(limitedList || _this.modifiedListItems));
+  var renderLoopIndex = 0;
+  var data = (limitedList || _this.modifiedListItems);
+  function render() {
+    // get the next batch of items to render
+    let nextBatch = data.slice(
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE,
+      renderLoopIndex * _this.INCREMENTAL_RENDERING_BATCH_SIZE + _this.INCREMENTAL_RENDERING_BATCH_SIZE
+    );
+    if (nextBatch.length) {
+      _this.$container.find('#small-card-list-wrapper-' + _this.data.id).append(template(nextBatch));
+      renderLoopIndex++;
+      // if the browser is ready, render
+      requestAnimationFrame(render);
+    }
+  }
+  // start the initial render
+  requestAnimationFrame(render);
 }
 
 DynamicList.prototype.getAddPermission = function(data) {


### PR DESCRIPTION
tl;dr https://www.useloom.com/share/cf12d0da214a4237830884b4bbbef5d8

Based on the discussion and ideas shared in https://github.com/Fliplet/fliplet-studio/issues/3582 I added some optimisations to the LFD so now it should load faster.

The largest performance hit we took was basically in a couple of quadratic complexity nested loops which were unneeded.
The next step to optimise was to reduce 2 unneeded sort/orderBy statements to one.
The final step was to introduce incremental rendering via [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame). In short, we batch all the records by 100s (configurable at code level) and render those batches to the screen whenever the browser gives us the opportunity to do so.
What that means is that we leave the browser some time to render the initial records, then when it's idle it can render the next ones and so on. 

**I will add some review comments on the places which needed optimisations**
### Development experience notes
Time to figure out where the perf hit was about 20 minutes with the use of Chrome's performance audit tools.
The time it took me to figure out where in code that was coming from and more importantly - why - took me about an hour and a half, due to the bloated and unseparated code.
Then, another 3 hours were spent to actually applying the fix to all components (which were all the same, but also somehow different) and test them out.

What I am saying is that all this would've been probably done in less than an hour if we had a consistent framework which has separation of concerns to its core.