### PR TITLE
Added a second sort condition by default - Agenda

### DIFF
--- a/js/default-configs/layouts-config.js
+++ b/js/default-configs/layouts-config.js
@@ -154,7 +154,15 @@ window.flListLayoutConfig = {
         'id': 'ajdmjZrT',
         'orderBy': 'ascending',
         'sortBy': 'date',
-        'title': 'Date - Date - Ascending'
+        'title': 'Full Date - Date - Ascending'
+      },
+      {
+        'column': 'Start Time',
+        'columns': ['Title', 'Full Date', 'Start Time', 'End Time', 'Location', 'Content'],
+        'id': 'bjzxjKrP',
+        'orderBy': 'ascending',
+        'sortBy': 'time',
+        'title': 'Start Time - Date - Ascending'
       }
     ],
     'social': {


### PR DESCRIPTION
This adds a new default sort condition to the Agenda style.
Making it so that it sorts by date first and then by time.

Reference of explanation why: https://github.com/Fliplet/fliplet-e2e-tests/issues/249

