### PR TITLE
Added a query parser to LFD

### DIFF
--- a/build.html
+++ b/build.html
@@ -37,25 +37,23 @@
       };
     </script>
     <div data-script-insert="{{ id }}" class="hidden"></div>
-    <script type="text/javascript" src="{{{ asset "js/query-parser.js" }}}"></script>
     <script type="text/javascript">
-      var script = document.createElement('script');
-      script.onload = function() {
-        if (typeof DynamicList !== 'function') {
-          console.warn('DynamicList() is not defined for widget for widget ID {{ id }}');
-          return;
-        }
-
-        var id = {{ id }};
-        DynamicListFuncs[id] = DynamicList;
-        DynamicList = null;
-        Fliplet().then(function () {
+      Fliplet().then(function(){
+        var script = document.createElement('script');
+        script.onload = function() {
+          if (typeof DynamicList !== 'function') {
+            console.warn('DynamicList() is not defined for widget for widget ID {{ id }}');
+            return;
+          }
+          var id = {{ id }};
+          DynamicListFuncs[id] = DynamicList;
+          DynamicList = null;
           var data = Fliplet.Widget.getData(id);
           dynamicLists[id] = new DynamicListFuncs[id](id, data);
-        })
-      };
-      script.src = assetUrl['{{ layout }}'];
-      document.querySelector('[data-script-insert="{{ id }}"]').appendChild(script);
+        };
+        script.src = assetUrl['{{ layout }}'];
+        document.querySelector('[data-script-insert="{{ id }}"]').appendChild(script);
+      });
     </script>
   {{/if}}
 {{else}}

--- a/build.html
+++ b/build.html
@@ -37,6 +37,7 @@
       };
     </script>
     <div data-script-insert="{{ id }}" class="hidden"></div>
+    <script type="text/javascript" src="{{{ asset "js/query-parser.js" }}}"></script>
     <script type="text/javascript">
       var script = document.createElement('script');
       script.onload = function() {

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -923,8 +923,15 @@ DynamicList.prototype.initialize = function() {
       });
   }
 
-  // Check if there is a PV for search/filter queries
-  _this.parsePVQueryVars()
+  var shouldInitFromQuery = _this.parseQueryVars();
+  // query will always have higher priority than storage
+  // if we find relevant terms in the query, delete the storage so the filters do not mix and produce side-effects
+  if(shouldInitFromQuery){
+    Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);
+  };
+
+  // Check if there is a query or PV for search/filter queries
+  (shouldInitFromQuery ? Promise.resolve() : _this.parsePVQueryVars())
     .then(function() {
       // Render Base HTML template
       _this.renderBaseHTML();
@@ -1018,6 +1025,8 @@ DynamicList.prototype.checkIsToOpen = function() {
 
   _this.showDetails(entry.id);
 }
+
+DynamicList.prototype.parseQueryVars = Fliplet.Registry.get('dynamicListQueryParser');
 
 DynamicList.prototype.parsePVQueryVars = function() {
   var _this = this;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1335,8 +1335,15 @@ DynamicList.prototype.initialize = function() {
       });
   }
 
-  // Check if there is a PV for search/filter queries
-  _this.parsePVQueryVars()
+  var shouldInitFromQuery = _this.parseQueryVars();
+  // query will always have higher priority than storage
+  // if we find relevant terms in the query, delete the storage so the filters do not mix and produce side-effects
+  if(shouldInitFromQuery){
+    Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);
+  };
+
+  // Check if there is a query or PV for search/filter queries
+  (shouldInitFromQuery ? Promise.resolve() : _this.parsePVQueryVars())
     .then(function() {
       // Render Base HTML template
       _this.renderBaseHTML();
@@ -1495,6 +1502,8 @@ DynamicList.prototype.navigateBackEvent = function() {
     });
   });
 }
+
+DynamicList.prototype.parseQueryVars = Fliplet.Registry.get('dynamicListQueryParser');
 
 DynamicList.prototype.parsePVQueryVars = function() {
   var _this = this;

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1163,8 +1163,15 @@ DynamicList.prototype.initialize = function() {
       });
   }
 
-  // Check if there is a PV for search/filter queries
-  _this.parsePVQueryVars()
+  var shouldInitFromQuery = _this.parseQueryVars();
+  // query will always have higher priority than storage
+  // if we find relevant terms in the query, delete the storage so the filters do not mix and produce side-effects
+  if(shouldInitFromQuery){
+    Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);
+  };
+
+  // Check if there is a query or PV for search/filter queries
+  (shouldInitFromQuery ? Promise.resolve() : _this.parsePVQueryVars())
     .then(function() {
       // Render Base HTML template
       _this.renderBaseHTML();
@@ -1328,6 +1335,8 @@ DynamicList.prototype.navigateBackEvent = function() {
     });
   });
 }
+
+DynamicList.prototype.parseQueryVars = Fliplet.Registry.get('dynamicListQueryParser');
 
 DynamicList.prototype.parsePVQueryVars = function() {
   var _this = this;

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -961,8 +961,15 @@ DynamicList.prototype.initialize = function() {
       });
   }
 
-  // Check if there is a PV for search/filter queries
-  _this.parsePVQueryVars()
+  var shouldInitFromQuery = _this.parseQueryVars();
+  // query will always have higher priority than storage
+  // if we find relevant terms in the query, delete the storage so the filters do not mix and produce side-effects
+  if(shouldInitFromQuery){
+    Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);
+  };
+
+  // Check if there is a query or PV for search/filter queries
+  (shouldInitFromQuery ? Promise.resolve() : _this.parsePVQueryVars())
     .then(function() {
       // Render Base HTML template
       _this.renderBaseHTML();
@@ -1157,6 +1164,8 @@ DynamicList.prototype.navigateBackEvent = function() {
   });
 }
 
+DynamicList.prototype.parseQueryVars = Fliplet.Registry.get('dynamicListQueryParser');
+
 DynamicList.prototype.parsePVQueryVars = function() {
   var _this = this;
   var pvValue;
@@ -1164,7 +1173,6 @@ DynamicList.prototype.parsePVQueryVars = function() {
   return Fliplet.App.Storage.get('flDynamicListQuery:' + _this.data.layout)
     .then(function(value) {
       pvValue = value;
-      console.log(pvValue);
 
       if (typeof value === 'undefined') {
         Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -712,8 +712,15 @@ DynamicList.prototype.initialize = function() {
       });
   }
 
-  // Check if there is a PV for search/filter queries
-  _this.parsePVQueryVars()
+  var shouldInitFromQuery = _this.parseQueryVars();
+  // query will always have higher priority than storage
+  // if we find relevant terms in the query, delete the storage so the filters do not mix and produce side-effects
+  if(shouldInitFromQuery){
+    Fliplet.App.Storage.remove('flDynamicListQuery:' + _this.data.layout);
+  };
+
+  // Check if there is a query or PV for search/filter queries
+  (shouldInitFromQuery ? Promise.resolve() : _this.parsePVQueryVars())
     .then(function() {
       // Render Base HTML template
       _this.renderBaseHTML();
@@ -800,6 +807,8 @@ DynamicList.prototype.checkIsToOpen = function() {
 
   _this.showDetails(entry.id);
 }
+
+DynamicList.prototype.parseQueryVars = Fliplet.Registry.get('dynamicListQueryParser');
 
 DynamicList.prototype.parsePVQueryVars = function() {
   var _this = this;

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -5,7 +5,7 @@
  */
 Fliplet.Registry.set('dynamicListQueryParser', function() {
 	// we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
-	this.previousScreen =Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
+	this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
 
 	// action is intentionally ommited so we don't open ourselves up to an xss attack
 	this.pvGoBack = _.pickBy({
@@ -98,7 +98,7 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
 		this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
 
 		// cast to boolean
-    this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
+		this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
 		this.data.filtersEnabled = this.queryFilter;
 	} else {
 		this.queryFilter = null;

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -4,111 +4,111 @@
  * for prepopulating, prefiltering and opening an entry
  */
 Fliplet.Registry.set('dynamicListQueryParser', function() {
-	// we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
-	this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
+  // we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
+  this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
 
-	// action is intentionally ommited so we don't open ourselves up to an xss attack
-	this.pvGoBack = _.pickBy({
-		enableButton: Fliplet.Navigate.query['dynamicListEnableButton'],
-		hijackBack: Fliplet.Navigate.query['dynamicListHijackBack']
-	});
-	this.queryGoBack = _(this.pvGoBack).size() > 0;
+  // action is intentionally ommited so we don't open ourselves up to an xss attack
+  this.pvGoBack = _.pickBy({
+    enableButton: Fliplet.Navigate.query['dynamicListEnableButton'],
+    hijackBack: Fliplet.Navigate.query['dynamicListHijackBack']
+  });
+  this.queryGoBack = _(this.pvGoBack).size() > 0;
 
-	// cast to booleans
-	this.pvGoBack.enableButton = this.pvGoBack.enableButton === 'true';
-	this.pvGoBack.hijackBack = this.pvGoBack.hijackBack === 'true';
-	this.pvGoBack = this.queryGoBack ? this.pvGoBack : null;
+  // cast to booleans
+  this.pvGoBack.enableButton = this.pvGoBack.enableButton === 'true';
+  this.pvGoBack.hijackBack = this.pvGoBack.hijackBack === 'true';
+  this.pvGoBack = this.queryGoBack ? this.pvGoBack : null;
 
-	// example input
-	// ?dynamicListPrefilterColumn=Name,Age&dynamicListPrefilterLogic=contains,<&dynamicListPrefilterValue=Angel,2
-	this.pvPreFilterQuery = _.pickBy({
-		column: Fliplet.Navigate.query['dynamicListPrefilterColumn'],
-		logic: Fliplet.Navigate.query['dynamicListPrefilterLogic'],
-		value: Fliplet.Navigate.query['dynamicListPrefilterValue']
-	});
-	this.queryPreFilter = _(this.pvPreFilterQuery).size() > 0;
+  // example input
+  // ?dynamicListPrefilterColumn=Name,Age&dynamicListPrefilterLogic=contains,<&dynamicListPrefilterValue=Angel,2
+  this.pvPreFilterQuery = _.pickBy({
+    column: Fliplet.Navigate.query['dynamicListPrefilterColumn'],
+    logic: Fliplet.Navigate.query['dynamicListPrefilterLogic'],
+    value: Fliplet.Navigate.query['dynamicListPrefilterValue']
+  });
+  this.queryPreFilter = _(this.pvPreFilterQuery).size() > 0;
 
-	if (this.queryPreFilter) {
-		// take the query parameters and parse them down to arrays
-		var prefilterColumnParts = this.pvPreFilterQuery.column ? this.pvPreFilterQuery.column.split(',') : [];
-		var prefilterLogicParts = this.pvPreFilterQuery.logic ? this.pvPreFilterQuery.logic.split(',') : [];
-		var prefilterValueParts = this.pvPreFilterQuery.value ? this.pvPreFilterQuery.value.split(',') : [];
+  if (this.queryPreFilter) {
+    // take the query parameters and parse them down to arrays
+    var prefilterColumnParts = this.pvPreFilterQuery.column ? this.pvPreFilterQuery.column.split(',') : [];
+    var prefilterLogicParts = this.pvPreFilterQuery.logic ? this.pvPreFilterQuery.logic.split(',') : [];
+    var prefilterValueParts = this.pvPreFilterQuery.value ? this.pvPreFilterQuery.value.split(',') : [];
 
-		if (
-			prefilterColumnParts.length !== prefilterLogicParts.length ||
-			prefilterLogicParts.length !== prefilterValueParts.length
-		) {
-			this.pvPreFilterQuery = null;
-			this.queryPreFilter = false;
-			console.warn('Please supply an equal number of parameter to the dynamicListPrefilter filters.');
-		} else {
-			this.pvPreFilterQuery = [];
-			var maxPartCount = Math.max(
-				prefilterColumnParts.length,
-				prefilterLogicParts.length,
-				prefilterValueParts.length
-			);
-			// loop through the query parts and create new filters with every one
-			for (let i = 0; i < maxPartCount; i++) {
-				var filter = {
-					column: prefilterColumnParts.pop(),
-					logic: prefilterLogicParts.pop(),
-					value: prefilterValueParts.pop()
-				};
-				this.pvPreFilterQuery.push(filter);
-			}
-		}
-	} else {
-		this.pvPreFilterQuery = null;
-	}
+    if (
+      prefilterColumnParts.length !== prefilterLogicParts.length ||
+      prefilterLogicParts.length !== prefilterValueParts.length
+    ) {
+      this.pvPreFilterQuery = null;
+      this.queryPreFilter = false;
+      console.warn('Please supply an equal number of parameter to the dynamicListPrefilter filters.');
+    } else {
+      this.pvPreFilterQuery = [];
+      var maxPartCount = Math.max(
+        prefilterColumnParts.length,
+        prefilterLogicParts.length,
+        prefilterValueParts.length
+      );
+      // loop through the query parts and create new filters with every one
+      for (let i = 0; i < maxPartCount; i++) {
+        var filter = {
+          column: prefilterColumnParts.pop(),
+          logic: prefilterLogicParts.pop(),
+          value: prefilterValueParts.pop()
+        };
+        this.pvPreFilterQuery.push(filter);
+      }
+    }
+  } else {
+    this.pvPreFilterQuery = null;
+  }
 
-	// dataSourceEntryId is always numeric
-	// we cast the one coming from query to a number
-	// so the equality check later passes
-	this.pvOpenQuery = _.pickBy({
-		id: parseInt(Fliplet.Navigate.query['dynamicListOpenId'], 10),
-		column: Fliplet.Navigate.query['dynamicListOpenColumn'],
-		value: Fliplet.Navigate.query['dynamicListOpenValue']
-	});
-	this.queryOpen = _(this.pvOpenQuery).size() > 0;
-	this.pvOpenQuery = this.queryOpen ? this.pvOpenQuery : null;
+  // dataSourceEntryId is always numeric
+  // we cast the one coming from query to a number
+  // so the equality check later passes
+  this.pvOpenQuery = _.pickBy({
+    id: parseInt(Fliplet.Navigate.query['dynamicListOpenId'], 10),
+    column: Fliplet.Navigate.query['dynamicListOpenColumn'],
+    value: Fliplet.Navigate.query['dynamicListOpenValue']
+  });
+  this.queryOpen = _(this.pvOpenQuery).size() > 0;
+  this.pvOpenQuery = this.queryOpen ? this.pvOpenQuery : null;
 
-	this.pvSearchQuery = _.pickBy({
-		column: Fliplet.Navigate.query['dynamicListSearchColumn'],
-		value: Fliplet.Navigate.query['dynamicListSearchValue']
-	});
-	this.querySearch = _(this.pvSearchQuery).size() > 0;
-	if (this.querySearch) {
-		// check if a comma separated list of columns were passed as column
-		var searchColumns = this.pvSearchQuery.column ? this.pvSearchQuery.column.split(',') : null;
-		this.pvSearchQuery.column = searchColumns && searchColumns.length ? searchColumns : this.pvSearchQuery.column;
-		this.data.searchEnabled = this.querySearch;
-	} else {
-		this.querySearch = null;
-	}
+  this.pvSearchQuery = _.pickBy({
+    column: Fliplet.Navigate.query['dynamicListSearchColumn'],
+    value: Fliplet.Navigate.query['dynamicListSearchValue']
+  });
+  this.querySearch = _(this.pvSearchQuery).size() > 0;
+  if (this.querySearch) {
+    // check if a comma separated list of columns were passed as column
+    var searchColumns = this.pvSearchQuery.column ? this.pvSearchQuery.column.split(',') : null;
+    this.pvSearchQuery.column = searchColumns && searchColumns.length ? searchColumns : this.pvSearchQuery.column;
+    this.data.searchEnabled = this.querySearch;
+  } else {
+    this.querySearch = null;
+  }
 
-	this.pvFilterQuery = _.pickBy({
-		value: Fliplet.Navigate.query['dynamicListFilterValue'],
-		hideControls: Fliplet.Navigate.query['dynamicListFilterHideControls']
-	});
-	this.queryFilter = _(this.pvFilterQuery).size() > 0;
-	if (this.queryFilter) {
-		// check if a comma separated list of columns were passed as column
-		var filterValues = this.pvFilterQuery.value ? this.pvFilterQuery.value.split(',') : null;
-		this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
+  this.pvFilterQuery = _.pickBy({
+    value: Fliplet.Navigate.query['dynamicListFilterValue'],
+    hideControls: Fliplet.Navigate.query['dynamicListFilterHideControls']
+  });
+  this.queryFilter = _(this.pvFilterQuery).size() > 0;
+  if (this.queryFilter) {
+    // check if a comma separated list of columns were passed as column
+    var filterValues = this.pvFilterQuery.value ? this.pvFilterQuery.value.split(',') : null;
+    this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
 
-		// cast to boolean
-		this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
-		this.data.filtersEnabled = this.queryFilter;
-	} else {
-		this.queryFilter = null;
-	}
-	return (
-		this.previousScreen ||
-		this.queryGoBack ||
-		this.queryPreFilter ||
-		this.queryOpen ||
-		this.querySearch ||
-		this.queryFilter
-	);
+    // cast to boolean
+    this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
+    this.data.filtersEnabled = this.queryFilter;
+  } else {
+    this.queryFilter = null;
+  }
+  return (
+    this.previousScreen ||
+    this.queryGoBack ||
+    this.queryPreFilter ||
+    this.queryOpen ||
+    this.querySearch ||
+    this.queryFilter
+  );
 });

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -1,0 +1,118 @@
+/**
+ * this basically gets data out of the url as an INPUT,
+ * parses it, and as an OUTPUT sets all the required variables used by LFD
+ * for prepopulating, prefiltering and opening an entry
+ */
+Fliplet.Registry.set('dynamicListQueryParser', function() {
+	// we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
+	this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen']
+		? Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true'
+		: false;
+
+	// action is intentionally ommited so we don't open ourselves up to an xss attack
+	this.pvGoBack = _.pickBy({
+		enableButton: Fliplet.Navigate.query['dynamicListEnableButton'],
+		hijackBack: Fliplet.Navigate.query['dynamicListHijackBack']
+	});
+	this.queryGoBack = _(this.pvGoBack).size() > 0;
+
+	// cast to booleans
+	this.pvGoBack.enableButton = this.pvGoBack.enableButton ? this.pvGoBack.enableButton === 'true' : false;
+	this.pvGoBack.hijackBack = this.pvGoBack.hijackBack ? this.pvGoBack.hijackBack === 'true' : false;
+	this.pvGoBack = this.queryGoBack ? this.pvGoBack : null;
+
+	// example input
+	// ?dynamicListPrefilterColumn=Name,Age&dynamicListPrefilterLogic=contains,<&dynamicListPrefilterValue=Angel,2
+	this.pvPreFilterQuery = _.pickBy({
+		column: Fliplet.Navigate.query['dynamicListPrefilterColumn'],
+		logic: Fliplet.Navigate.query['dynamicListPrefilterLogic'],
+		value: Fliplet.Navigate.query['dynamicListPrefilterValue']
+	});
+	this.queryPreFilter = _(this.pvPreFilterQuery).size() > 0;
+
+	if (this.queryPreFilter) {
+		// take the query parameters and parse them down to arrays
+		var prefilterColumnParts = this.pvPreFilterQuery.column ? this.pvPreFilterQuery.column.split(',') : [];
+		var prefilterLogicParts = this.pvPreFilterQuery.logic ? this.pvPreFilterQuery.logic.split(',') : [];
+		var prefilterValueParts = this.pvPreFilterQuery.value ? this.pvPreFilterQuery.value.split(',') : [];
+
+		if (
+			prefilterColumnParts.length !== prefilterLogicParts.length ||
+			prefilterLogicParts.length !== prefilterValueParts.length
+		) {
+			this.pvPreFilterQuery = null;
+			this.queryPreFilter = false;
+			console.warn('Please supply an equal number of parameter to the dynamicListPrefilter filters.');
+		} else {
+			this.pvPreFilterQuery = [];
+			var maxPartCount = Math.max(
+				prefilterColumnParts.length,
+				prefilterLogicParts.length,
+				prefilterValueParts.length
+			);
+			// loop through the query parts and create new filters with every one
+			for (let i = 0; i < maxPartCount; i++) {
+				var filter = {
+					column: prefilterColumnParts.pop(),
+					logic: prefilterLogicParts.pop(),
+					value: prefilterValueParts.pop()
+				};
+				this.pvPreFilterQuery.push(filter);
+			}
+		}
+	} else {
+		this.pvPreFilterQuery = null;
+	}
+
+	// dataSourceEntryId is always numeric
+	// we cast the one coming from query to a number
+	// so the equality check later passes
+	this.pvOpenQuery = _.pickBy({
+		id: parseInt(Fliplet.Navigate.query['dynamicListOpenId'], 10),
+		column: Fliplet.Navigate.query['dynamicListOpenColumn'],
+		value: Fliplet.Navigate.query['dynamicListOpenValue']
+	});
+	this.queryOpen = _(this.pvOpenQuery).size() > 0;
+	this.pvOpenQuery = this.queryOpen ? this.pvOpenQuery : null;
+
+	this.pvSearchQuery = _.pickBy({
+		column: Fliplet.Navigate.query['dynamicListSearchColumn'],
+		value: Fliplet.Navigate.query['dynamicListSearchValue']
+	});
+	this.querySearch = _(this.pvSearchQuery).size() > 0;
+	if (this.querySearch) {
+		// check if a comma separated list of columns were passed as column
+		var searchColumns = this.pvSearchQuery.column ? this.pvSearchQuery.column.split(',') : null;
+		this.pvSearchQuery.column = searchColumns && searchColumns.length ? searchColumns : this.pvSearchQuery.column;
+		this.data.searchEnabled = this.querySearch;
+	} else {
+		this.querySearch = null;
+	}
+
+	this.pvFilterQuery = _.pickBy({
+		value: Fliplet.Navigate.query['dynamicListFilterValue'],
+		hideControls: Fliplet.Navigate.query['dynamicListFilterHideControls']
+	});
+	this.queryFilter = _(this.pvFilterQuery).size() > 0;
+	if (this.queryFilter) {
+		// check if a comma separated list of columns were passed as column
+		var filterValues = this.pvFilterQuery.value ? this.pvFilterQuery.value.split(',') : null;
+		this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
+
+		// cast to boolean
+		(this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls
+			? this.pvFilterQuery.hideControls === 'true'
+			: false),
+			(this.data.filtersEnabled = this.queryFilter);
+	} else {
+		this.queryFilter = null;
+	}
+	return (
+		this.previousScreen ||
+		this.queryGoBack ||
+		this.queryPreFilter ||
+		this.queryOpen ||
+		this.querySearch ||
+		this.queryFilter
+	);
+});

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -5,9 +5,7 @@
  */
 Fliplet.Registry.set('dynamicListQueryParser', function() {
 	// we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
-	this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen']
-		? Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true'
-		: false;
+	this.previousScreen =Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
 
 	// action is intentionally ommited so we don't open ourselves up to an xss attack
 	this.pvGoBack = _.pickBy({
@@ -17,8 +15,8 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
 	this.queryGoBack = _(this.pvGoBack).size() > 0;
 
 	// cast to booleans
-	this.pvGoBack.enableButton = this.pvGoBack.enableButton ? this.pvGoBack.enableButton === 'true' : false;
-	this.pvGoBack.hijackBack = this.pvGoBack.hijackBack ? this.pvGoBack.hijackBack === 'true' : false;
+	this.pvGoBack.enableButton = this.pvGoBack.enableButton === 'true';
+	this.pvGoBack.hijackBack = this.pvGoBack.hijackBack === 'true';
 	this.pvGoBack = this.queryGoBack ? this.pvGoBack : null;
 
 	// example input
@@ -100,10 +98,8 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
 		this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
 
 		// cast to boolean
-		(this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls
-			? this.pvFilterQuery.hideControls === 'true'
-			: false),
-			(this.data.filtersEnabled = this.queryFilter);
+    this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
+		this.data.filtersEnabled = this.queryFilter;
 	} else {
 		this.queryFilter = null;
 	}

--- a/widget.json
+++ b/widget.json
@@ -67,6 +67,7 @@
       "hammer.js"
     ],
     "assets": [
+      "js/query-parser.js",
       "js/build.templates.js",
       "vendor/mixitup.min.js",
       "vendor/mixitup-multifilter.min.js",


### PR DESCRIPTION
This PR adds a query parser to all LFD layouts.
I've followed a similar naming convention to the one for Storage.
These are some examples of queries which will work the same way as if they were applied through PV (i.e Storage):
`dynamicListOpenId=1128` - opens a specific entry

`dynamicListSearchColumn=Name&dynamicListSearchValue=Angel` - will search for `Angel` in the column `Name`

`dynamicListFilterValue=Angel,28` - will select the filter options `Angel` and `28`

`dynamicListFilterValue=Angel,28&dynamicListFilterHideControls=true` - will select the filter options `Angel` and `28` **and will also hide the controls**

`dynamicListPrefilterColumn=Name&dynamicListPrefilterValue=Angel&dynamicListPrefilterLogic=contains` - will pre-filter the list, by testing if any `Name` `contains` `Angel`

`dynamicListPrefilterColumn=Name,Age&dynamicListPrefilterValue=Younger,29&dynamicListPrefilterLogic=contains,%3C` - will pre-filter the list, by testing if any `Name` `contains` `Angel` AND `Age` `is lower` than `29`

**NOTE**
I intentionally left out two callbacks which could be passed to the LFD through storage.
Both `goBack.action` and  `previousScreen` are evaluated in the browser of the user and while we are certain that no malicious code could have been inserted in the Storage, because a user having access to the project must have added those callbacks there, we can't be sure that someone won't click on a shortened url, containing a function in the url which once executed - could harm the user in some way.