### PR TITLE
Fix to the expand animation of small cards

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -631,6 +631,12 @@
   transform: translate3d(0, 0, 0);
 }
 
+.new-small-card-list-container .small-card-list-item.opening .small-card-list-image {
+  overflow: initial;
+  -webkit-transform: none;
+  transform: none;
+}
+
 .new-small-card-list-container .small-card-list-image.no-image {
   display: none;
 }

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2220,6 +2220,7 @@ DynamicList.prototype.closeDetails = function() {
 
   setTimeout(function() {
     $overlay.removeClass('ready');
+
     // Clears overlay
     $overlay.find('.small-card-detail-overlay-content-holder').html('');
 
@@ -2243,6 +2244,7 @@ DynamicList.prototype.expandElement = function(elementToExpand, id) {
   if (!elementToExpand.hasClass('open')) {
     // freeze the current scroll position of the background content
     $('body').addClass('lock');
+    elementToExpand.parents('.small-card-list-item').addClass('opening');
 
     var currentPosition = elementToExpand.offset();
     var elementScrollTop = $(window).scrollTop();
@@ -2276,6 +2278,10 @@ DynamicList.prototype.expandElement = function(elementToExpand, id) {
       'max-width': expandWidth
     }, 200, 'linear', function() {
       _this.showDetails(id);
+
+      setTimeout(function() {
+        elementToExpand.parents('.small-card-list-item').removeClass('opening');
+      }, 200); // How long it takes for the overlay to fade in
     });
 
     elementToExpand.addClass('open');
@@ -2310,6 +2316,7 @@ DynamicList.prototype.collapseElement = function(elementToCollapse) {
   var _this = this;
 
   $('body').removeClass('lock');
+  elementToCollapse.parents('.small-card-list-item').addClass('closing');
 
   var directoryDetailImageWrapper = elementToCollapse.find('.small-card-list-detail-image-wrapper');
   var directoryDetailImage = elementToCollapse.find('.small-card-list-detail-image');
@@ -2353,6 +2360,7 @@ DynamicList.prototype.collapseElement = function(elementToCollapse) {
   function() {
     elementToCollapse.css({ height: '100%', });
     _this.closeDetails();
+    elementToCollapse.parents('.small-card-list-item').removeClass('opening');
 
     // This bit of code will only be useful if this component is added inside a Fliplet's Accordion component
     // Only happens when the closing animation finishes


### PR DESCRIPTION
- With this PR we now have a `.opening` and `.closing` classes added to the list item element, to be used in the CSS to control how elements react during the animation.
- We used the `.opening` class to restore the expand animation that was "broken" after a change that fixes round corners from disappearing on specific devices.

![Screen Recording 2019-03-20 at 11 56 am](https://user-images.githubusercontent.com/7046481/54682750-a7962500-4b07-11e9-918f-e2a428887ba3.gif)
