### PR TITLE
Removed use of unnecessary use of body position

### DIFF
--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2250,9 +2250,6 @@ DynamicList.prototype.expandElement = function(elementToExpand, id) {
     var elementScrollTop = $(window).scrollTop();
     var netOffset = currentPosition.top - elementScrollTop;
 
-    var expandPosition = $('body').offset();
-    var expandTop = expandPosition.top;
-    var expandLeft = expandPosition.left;
     var expandWidth = $('body').outerWidth();
     var expandHeight = $('html').outerHeight();
 
@@ -2271,8 +2268,8 @@ DynamicList.prototype.expandElement = function(elementToExpand, id) {
     });
 
     elementToExpand.animate({
-      'left': expandLeft,
-      'top': expandTop,
+      'left': 0,
+      'top': 0,
       'height': expandHeight,
       'width': expandWidth,
       'max-width': expandWidth


### PR DESCRIPTION
After a closer look at how the expand works now (compared to the initial versions of the LFD) I noticed that we actually do not require the position of the body at all, because we know that the overlay that will fade in after the expand animation is always filling the screen on mobile.

This change won't affect the Tablet and Desktop animations/overlay.

https://cl.ly/df2c5785e680