### PR TITLE
Ensures offline resources are used for all layouts

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -72,7 +72,7 @@ var DynamicList = function(id, data, container) {
   // Register handlebars helpers
   this.registerHandlebarsHelpers();
   // Get the current session data
-  Fliplet.Session.get()
+  Fliplet.User.getCachedSession()
     .then(function(session) {
       if (session && session.entries && session.entries.dataSource) {
         _this.myUserData = session.entries.dataSource.data;

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -998,17 +998,21 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function() {
+      if (!_this.data.detailViewAutoUpdate) {
+        return Promise.resolve();
+      }
+
       return Fliplet.DataSources.getById(_this.data.dataSourceId)
+        .then(function(dataSource) {
+          if (!dataSource) {
+            return Promise.resolve();
+          }
+
+          _this.dataSourceColumns = dataSource.columns;
+        })
         .catch(function () {
           return Promise.resolve(); // Resolve anyway if it fails
         });
-    })
-    .then(function(dataSource) {
-      if (dataSource) {
-        _this.dataSourceColumns = dataSource.columns;
-      }
-
-      return;
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1362,29 +1362,26 @@ DynamicList.prototype.prepareToRenderLoop = function(rows) {
   })
 
   // Converts date format
-  loopData.forEach(function(obj, index) {
-    if (_this.data.detailViewAutoUpdate) {
-      var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
-      if (extraColumns && extraColumns.length) {
+  var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
+  if (_this.data.detailViewAutoUpdate && extraColumns.length) {
+    loopData.forEach(function(obj, index) {
+      var entryData = _.find(clonedRecords, function(modEntry) {
+        return modEntry.id === obj.id;
+      });
 
-        var entryData = _.find(clonedRecords, function(modEntry) {
-          return modEntry.id === obj.id;
-        });
+      extraColumns.forEach(function(column) {
+        var newColumnData = {
+          id: entryData.id,
+          content: entryData.data[column],
+          label: column,
+          labelEnabled: true,
+          type: 'text'
+        };
 
-        extraColumns.forEach(function(column) {
-          var newColumnData = {
-            id: entryData.id,
-            content: entryData.data[column],
-            label: column,
-            labelEnabled: true,
-            type: 'text'
-          };
-
-          obj.entryDetails.push(newColumnData);
-        });
-      }
-    }
-  });
+        obj.entryDetails.push(newColumnData);
+      });
+    });
+  }
 
   _this.agendasByDay = _this.groupLoopDataByDate(loopData, dateField);;
 }

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -931,6 +931,20 @@ DynamicList.prototype.connectToGetFiles = function(data) {
     });
 }
 
+DynamicList.prototype.getAllColumns = function () {
+  var cachedColumns = {};
+
+  if (cachedColumns[dataSourceId]) {
+    return Promise.resolve(cachedColumns[dataSourceId]);
+  }
+
+  this.listItems.unshift({});
+  cachedColumns[dataSourceId] = _.keys(_.extend.apply({}, _.map(this.listItems, 'data')));
+  this.listItems.shift();
+
+  return Promise.resolve(cachedColumns[dataSourceId]);
+};
+
 DynamicList.prototype.initialize = function() {
   var _this = this;
 
@@ -1002,17 +1016,9 @@ DynamicList.prototype.initialize = function() {
         return Promise.resolve();
       }
 
-      return Fliplet.DataSources.getById(_this.data.dataSourceId)
-        .then(function(dataSource) {
-          if (!dataSource) {
-            return Promise.resolve();
-          }
-
-          _this.dataSourceColumns = dataSource.columns;
-        })
-        .catch(function () {
-          return Promise.resolve(); // Resolve anyway if it fails
-        });
+      return _this.getAllColumns().then(function (columns) {
+        _this.dataSourceColumns = columns;
+      });
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1382,17 +1382,21 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function() {
+      if (!_this.data.detailViewAutoUpdate) {
+        return Promise.resolve();
+      }
+
       return Fliplet.DataSources.getById(_this.data.dataSourceId)
+        .then(function(dataSource) {
+          if (!dataSource) {
+            return Promise.resolve();
+          }
+
+          _this.dataSourceColumns = dataSource.columns;
+        })
         .catch(function () {
           return Promise.resolve(); // Resolve anyway if it fails
         });
-    })
-    .then(function(dataSource) {
-      if (dataSource) {
-        _this.dataSourceColumns = dataSource.columns;
-      }
-
-      return;
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -85,7 +85,7 @@ var DynamicList = function(id, data, container) {
   this.registerHandlebarsHelpers();
 
   // Get the current session data
-  Fliplet.Session.get().then(function(session) {
+  Fliplet.User.getCachedSession().then(function(session) {
     if (session && session.entries && session.entries.dataSource) {
       _this.myUserData = session.entries.dataSource.data;
     } else if (session && session.entries && session.entries.saml2) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1742,27 +1742,24 @@ DynamicList.prototype.prepareToRenderLoop = function(records) {
     return data.column;
   })
 
-  if (_this.data.detailViewAutoUpdate) {
+  var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
+  if (_this.data.detailViewAutoUpdate && extraColumns.length) {
     loopData.forEach(function(entry, index) {
-      var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
-      if (extraColumns && extraColumns.length) {
+      var entryData = _.find(modifiedData, function(modEntry) {
+        return modEntry.id === entry.id;
+      });
 
-        var entryData = _.find(modifiedData, function(modEntry) {
-          return modEntry.id === entry.id;
-        });
+      extraColumns.forEach(function(column) {
+        var newColumnData = {
+          id: entryData.id,
+          content: entryData.data[column],
+          label: column,
+          labelEnabled: true,
+          type: 'text'
+        };
 
-        extraColumns.forEach(function(column) {
-          var newColumnData = {
-            id: entryData.id,
-            content: entryData.data[column],
-            label: column,
-            labelEnabled: true,
-            type: 'text'
-          };
-
-          entry.entryDetails.push(newColumnData);
-        });
-      }
+        entry.entryDetails.push(newColumnData);
+      });
     });
   }
   _this.modifiedListItems = loopData;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1325,6 +1325,20 @@ DynamicList.prototype.connectToGetFiles = function(data) {
     });
 }
 
+DynamicList.prototype.getAllColumns = function () {
+  var cachedColumns = {};
+
+  if (cachedColumns[dataSourceId]) {
+    return Promise.resolve(cachedColumns[dataSourceId]);
+  }
+
+  this.listItems.unshift({});
+  cachedColumns[dataSourceId] = _.keys(_.extend.apply({}, _.map(this.listItems, 'data')));
+  this.listItems.shift();
+
+  return Promise.resolve(cachedColumns[dataSourceId]);
+};
+
 DynamicList.prototype.initialize = function() {
   var _this = this;
 
@@ -1386,17 +1400,9 @@ DynamicList.prototype.initialize = function() {
         return Promise.resolve();
       }
 
-      return Fliplet.DataSources.getById(_this.data.dataSourceId)
-        .then(function(dataSource) {
-          if (!dataSource) {
-            return Promise.resolve();
-          }
-
-          _this.dataSourceColumns = dataSource.columns;
-        })
-        .catch(function () {
-          return Promise.resolve(); // Resolve anyway if it fails
-        });
+      return _this.getAllColumns().then(function (columns) {
+        _this.dataSourceColumns = columns;
+      });
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -79,7 +79,7 @@ var DynamicList = function(id, data, container) {
   // Register handlebars helpers
   this.registerHandlebarsHelpers();
   // Get the current session data
-  Fliplet.Session.get().then(function(session) {
+  Fliplet.User.getCachedSession().then(function(session) {
     if (session && session.entries && session.entries.dataSource) {
       _this.myUserData = session.entries.dataSource.data;
     } else if (session && session.entries && session.entries.saml2) {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1212,17 +1212,21 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function() {
+      if (!_this.data.detailViewAutoUpdate) {
+        return Promise.resolve();
+      }
+
       return Fliplet.DataSources.getById(_this.data.dataSourceId)
+        .then(function(dataSource) {
+          if (!dataSource) {
+            return Promise.resolve();
+          }
+
+          _this.dataSourceColumns = dataSource.columns;
+        })
         .catch(function () {
           return Promise.resolve(); // Resolve anyway if it fails
         });
-    })
-    .then(function(dataSource) {
-      if (dataSource) {
-        _this.dataSourceColumns = dataSource.columns;
-      }
-
-      return;
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2491,20 +2491,18 @@ DynamicList.prototype.showDetails = function(id) {
     savedColumns.push(obj.column);
   });
 
+  var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
   if (_this.data.detailViewAutoUpdate) {
-    var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
-    if (extraColumns && extraColumns.length) {
-      extraColumns.forEach(function(column) {
-        var newColumnData = {
-          content: entryData.data[column],
-          label: column,
-          labelEnabled: true,
-          type: 'text'
-        };
+    extraColumns.forEach(function(column) {
+      var newColumnData = {
+        content: entryData.data[column],
+        label: column,
+        labelEnabled: true,
+        type: 'text'
+      };
 
-        newData.data.push(newColumnData);
-      });
-    }
+      newData.data.push(newColumnData);
+    });
   }
 
   // Process template with data

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1153,6 +1153,20 @@ DynamicList.prototype.connectToGetFiles = function(data) {
     });
 }
 
+DynamicList.prototype.getAllColumns = function () {
+  var cachedColumns = {};
+
+  if (cachedColumns[dataSourceId]) {
+    return Promise.resolve(cachedColumns[dataSourceId]);
+  }
+
+  this.listItems.unshift({});
+  cachedColumns[dataSourceId] = _.keys(_.extend.apply({}, _.map(this.listItems, 'data')));
+  this.listItems.shift();
+
+  return Promise.resolve(cachedColumns[dataSourceId]);
+};
+
 DynamicList.prototype.initialize = function() {
   var _this = this;
 
@@ -1216,17 +1230,9 @@ DynamicList.prototype.initialize = function() {
         return Promise.resolve();
       }
 
-      return Fliplet.DataSources.getById(_this.data.dataSourceId)
-        .then(function(dataSource) {
-          if (!dataSource) {
-            return Promise.resolve();
-          }
-
-          _this.dataSourceColumns = dataSource.columns;
-        })
-        .catch(function () {
-          return Promise.resolve(); // Resolve anyway if it fails
-        });
+      return _this.getAllColumns().then(function (columns) {
+        _this.dataSourceColumns = columns;
+      });
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1028,17 +1028,21 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function() {
+      if (!_this.data.detailViewAutoUpdate) {
+        return Promise.resolve();
+      }
+
       return Fliplet.DataSources.getById(_this.data.dataSourceId)
+        .then(function(dataSource) {
+          if (!dataSource) {
+            return Promise.resolve();
+          }
+
+          _this.dataSourceColumns = dataSource.columns;
+        })
         .catch(function () {
           return Promise.resolve(); // Resolve anyway if it fails
         });
-    })
-    .then(function(dataSource) {
-      if (dataSource) {
-        _this.dataSourceColumns = dataSource.columns;
-      }
-
-      return;
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -921,6 +921,20 @@ DynamicList.prototype.connectToGetFiles = function(data) {
     });
 }
 
+DynamicList.prototype.getAllColumns = function () {
+  var cachedColumns = {};
+
+  if (cachedColumns[dataSourceId]) {
+    return Promise.resolve(cachedColumns[dataSourceId]);
+  }
+
+  this.listItems.unshift({});
+  cachedColumns[dataSourceId] = _.keys(_.extend.apply({}, _.map(this.listItems, 'data')));
+  this.listItems.shift();
+
+  return Promise.resolve(cachedColumns[dataSourceId]);
+};
+
 DynamicList.prototype.initialize = function() {
   var _this = this;
 
@@ -1032,17 +1046,9 @@ DynamicList.prototype.initialize = function() {
         return Promise.resolve();
       }
 
-      return Fliplet.DataSources.getById(_this.data.dataSourceId)
-        .then(function(dataSource) {
-          if (!dataSource) {
-            return Promise.resolve();
-          }
-
-          _this.dataSourceColumns = dataSource.columns;
-        })
-        .catch(function () {
-          return Promise.resolve(); // Resolve anyway if it fails
-        });
+      return _this.getAllColumns().then(function (columns) {
+        _this.dataSourceColumns = columns;
+      });
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -80,7 +80,7 @@ var DynamicList = function(id, data, container) {
 
   this.registerHandlebarsHelpers();
   // Get the current session data
-  Fliplet.Session.get().then(function(session) {
+  Fliplet.User.getCachedSession().then(function(session) {
     if (session && session.entries && session.entries.dataSource) {
       _this.myUserData = session.entries.dataSource.data;
     } else if (session && session.entries && session.entries.saml2) {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1418,27 +1418,24 @@ DynamicList.prototype.prepareToRenderLoop = function(records, forProfile) {
     return data.column;
   })
 
-  if (_this.data.detailViewAutoUpdate) {
+  var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
+  if (_this.data.detailViewAutoUpdate && extraColumns.length) {
     loopData.forEach(function(obj, index) {
-      var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
-      if (extraColumns && extraColumns.length) {
+      var entryData = _.find(modifiedData, function(modEntry) {
+        return modEntry.id === obj.id;
+      });
 
-        var entryData = _.find(modifiedData, function(modEntry) {
-          return modEntry.id === obj.id;
-        });
+      extraColumns.forEach(function(column) {
+        var newColumnData = {
+          id: entryData.id,
+          content: entryData.data[column],
+          label: column,
+          labelEnabled: true,
+          type: 'text'
+        };
 
-        extraColumns.forEach(function(column) {
-          var newColumnData = {
-            id: entryData.id,
-            content: entryData.data[column],
-            label: column,
-            labelEnabled: true,
-            type: 'text'
-          };
-
-          obj.entryDetails.push(newColumnData);
-        });
-      }
+        obj.entryDetails.push(newColumnData);
+      });
     });
   }
 

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -1035,27 +1035,24 @@ DynamicList.prototype.prepareToRenderLoop = function(records) {
     return data.column;
   })
 
+  var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
   loopData.forEach(function(obj, index) {
-    if (_this.data.detailViewAutoUpdate) {
-      var extraColumns = _.difference(_this.dataSourceColumns, savedColumns);
-      if (extraColumns && extraColumns.length) {
+    if (_this.data.detailViewAutoUpdate && extraColumns.length) {
+      var entryData = _.find(records, function(modEntry) {
+        return modEntry.id === obj.id;
+      });
 
-        var entryData = _.find(records, function(modEntry) {
-          return modEntry.id === obj.id;
-        });
+      extraColumns.forEach(function(column) {
+        var newColumnData = {
+          id: entryData.id,
+          content: entryData.data[column],
+          label: column,
+          labelEnabled: true,
+          type: 'text'
+        };
 
-        extraColumns.forEach(function(column) {
-          var newColumnData = {
-            id: entryData.id,
-            content: entryData.data[column],
-            label: column,
-            labelEnabled: true,
-            type: 'text'
-          };
-
-          obj.entryDetails.push(newColumnData);
-        });
-      }
+        obj.entryDetails.push(newColumnData);
+      });
     }
 
     obj.profileHTML = _this.profileHTML(obj);

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -63,7 +63,7 @@ var DynamicList = function(id, data, container) {
 
   this.registerHandlebarsHelpers();
   // Get the current session data
-  Fliplet.Session.get().then(function(session) {
+  Fliplet.User.getCachedSession().then(function(session) {
     if (session && session.entries && session.entries.dataSource) {
       _this.myUserData = session.entries.dataSource.data;
     } else if (session && session.entries && session.entries.saml2) {

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -690,6 +690,20 @@ DynamicList.prototype.connectToGetFiles = function(data) {
     });
 }
 
+DynamicList.prototype.getAllColumns = function () {
+  var cachedColumns = {};
+
+  if (cachedColumns[dataSourceId]) {
+    return Promise.resolve(cachedColumns[dataSourceId]);
+  }
+
+  this.listItems.unshift({});
+  cachedColumns[dataSourceId] = _.keys(_.extend.apply({}, _.map(this.listItems, 'data')));
+  this.listItems.shift();
+
+  return Promise.resolve(cachedColumns[dataSourceId]);
+};
+
 DynamicList.prototype.initialize = function() {
   var _this = this;
 
@@ -779,17 +793,9 @@ DynamicList.prototype.initialize = function() {
         return Promise.resolve();
       }
 
-      return Fliplet.DataSources.getById(_this.data.dataSourceId)
-        .then(function(dataSource) {
-          if (!dataSource) {
-            return Promise.resolve();
-          }
-
-          _this.dataSourceColumns = dataSource.columns;
-        })
-        .catch(function () {
-          return Promise.resolve(); // Resolve anyway if it fails
-        });
+      return _this.getAllColumns().then(function (columns) {
+        _this.dataSourceColumns = columns;
+      });
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -775,17 +775,21 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function() {
+      if (!_this.data.detailViewAutoUpdate) {
+        return Promise.resolve();
+      }
+
       return Fliplet.DataSources.getById(_this.data.dataSourceId)
+        .then(function(dataSource) {
+          if (!dataSource) {
+            return Promise.resolve();
+          }
+
+          _this.dataSourceColumns = dataSource.columns;
+        })
         .catch(function () {
           return Promise.resolve(); // Resolve anyway if it fails
         });
-    })
-    .then(function(dataSource) {
-      if (dataSource) {
-        _this.dataSourceColumns = dataSource.columns;
-      }
-
-      return;
     })
     .then(function() {
       return _this.convertFiles(_this.listItems);


### PR DESCRIPTION
This includes:

1. [x] Getting user session via `Fliplet.Session.get()` is updated to use `Fliplet.User.getCachedSession()`
1. [x] Getting the most recent list of data source columns is updated to only when `detailViewAutoUpdate` is enabled
1. [x] Getting the most recent list of data source columns is updated to use a collation of all data source entries.

Other API changes that would also speed up the LFD:

1. `Fliplet.Media.Folders.get()` updated to use cached response and increase load speed (https://github.com/Fliplet/fliplet-api/pull/3290)
1. Use offline resource where possible when using `Fliplet.Content` or `Fliplet.Profile.Content`, speeding up loading and processing time for bookmarks. (https://github.com/Fliplet/fliplet-api/pull/3289)