### PR TITLE
Improves parser to ensure Agenda dates are correct

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -119,9 +119,9 @@ Fliplet.Registry.set('dynamicListUtils', function() {
 
     if (date.match(/^\d{4}-\d{2}-\d{2}/)) {
       return moment(new Date(date.substr(0, 10))).utc();
-    } else if (!Fliplet.DynamicList.isoWarningIssued) {
+    } else if (!isoDateWarningIssued) {
       console.warn('Date input is not provided in ISO format. This may create inconsistency in the app. We recommend ensuring the date is formatted in ISO format, e.g. ' + new Date().toISOString().substr(0, 10));
-      Fliplet.DynamicList.isoWarningIssued = true;
+      isoDateWarningIssued = true;
     }
 
     return moment(new Date(date));

--- a/js/utils.js
+++ b/js/utils.js
@@ -117,17 +117,14 @@ Fliplet.Registry.set('dynamicListUtils', function() {
       return moment(date);
     }
 
-    // Date is a string
-    var d = new Date(date);
-
-    if (date.match(/\d{4}-\d{2}-\d{2}(T| )?(\d{2}:\d{2}:\d{2})?/)) {
-      d = d.toUTCString();
-    } else if (!isoDateWarningIssued) {
+    if (date.match(/^\d{4}-\d{2}-\d{2}/)) {
+      return moment(new Date(date.substr(0, 10))).utc();
+    } else if (!Fliplet.DynamicList.isoWarningIssued) {
       console.warn('Date input is not provided in ISO format. This may create inconsistency in the app. We recommend ensuring the date is formatted in ISO format, e.g. ' + new Date().toISOString().substr(0, 10));
-      isoDateWarningIssued = true;
+      Fliplet.DynamicList.isoWarningIssued = true;
     }
 
-    return moment(d);
+    return moment(new Date(date));
   };
 
   function recordContains(record, value) {


### PR DESCRIPTION
Improves parser to exclude timezone depending on date format

Ref. https://github.com/Fliplet/fliplet-studio/issues/4030 and https://github.com/Fliplet/fliplet-studio/issues/3835

- Parses date using just the date string if it starts with the ISO date format
- Only converts moment to UTC time if the date string starts with the ISO date format

This ensures the recommended input format always works, and any other format is issued a warning before letting `Date` and `moment` parse its value.