### PR TITLE
Limit bookmarking like queries to only user entries

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1669,7 +1669,8 @@ DynamicList.prototype.setupBookmarkButton = function(id, identifier, title) {
       likedLabel: '<span class="fa fa-bookmark"></span>',
       likeWrapper: '<div class="bookmark-wrapper btn-bookmark"></div>',
       likedWrapper: '<div class="bookmark-wrapper btn-bookmarked"></div>',
-      addType: 'prepend'
+      addType: 'prepend',
+      getAllCounts: false
     }),
     id: id
   };

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2289,7 +2289,8 @@ DynamicList.prototype.setupBookmarkButton = function(id, identifier, title) {
       likedLabel: '<i class="fa fa-bookmark fa-lg animated fadeIn"></i>',
       likeWrapper: '<div class="news-feed-bookmark-wrapper btn-bookmark"></div>',
       likedWrapper: '<div class="news-feed-bookmark-wrapper btn-bookmarked"></div>',
-      addType: 'html'
+      addType: 'html',
+      getAllCounts: false
     }),
     id: id
   });

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2065,7 +2065,8 @@ DynamicList.prototype.setupBookmarkButton = function(id, identifier, title) {
       likedLabel: '<i class="fa fa-bookmark fa-lg animated fadeIn"></i>',
       likeWrapper: '<div class="simple-list-bookmark-wrapper btn-bookmark"></div>',
       likedWrapper: '<div class="simple-list-bookmark-wrapper btn-bookmarked"></div>',
-      addType: 'html'
+      addType: 'html',
+      getAllCounts: false
     }),
     id: id
   });

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1920,7 +1920,8 @@ DynamicList.prototype.setupBookmarkButton = function(id, identifier, title) {
       likedLabel: '<i class="fa fa-bookmark animated fadeIn"></i>',
       likeWrapper: '<div class="small-card-bookmark-wrapper btn-bookmark"></div>',
       likedWrapper: '<div class="small-card-bookmark-wrapper btn-bookmarked"></div>',
-      addType: 'html'
+      addType: 'html',
+      getAllCounts: false
     }),
     id: id
   });


### PR DESCRIPTION
Requires https://github.com/Fliplet/fliplet-api/pull/3322

@squallstar https://github.com/Fliplet/fliplet-api/pull/3322 reverted the default back to retrieving all data when reading like/bookmark status & counts. Options have been added here when creating the like button so that in the case of bookmarking LFD can retrieve entries specific to the user.

Ideally though, it would be better to be able to only retrieve a count number instead of reading all the entries and then doing a count on the client side.