### PR TITLE
Ignore special characters when performing searches

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -127,6 +127,10 @@ Fliplet.Registry.set('dynamicListUtils', function() {
     return moment(new Date(date));
   }
 
+  function removeSymbols(str) {
+    return ('' + str).replace(/[&\/\\#,+()$~%.'‘’"“”:*?<>{}]+/g, '');
+  }
+
   function recordContains(record, value) {
     if (!record) {
       return false;
@@ -144,13 +148,10 @@ Fliplet.Registry.set('dynamicListUtils', function() {
       });
     }
 
-    if (typeof record !== 'string') {
-      record = '' + record;
-    }
+    record = removeSymbols(record).toLowerCase();
+    value = removeSymbols(value).toLowerCase().trim();
 
-    value = ('' + value).toLowerCase().trim();
-
-    return record.toLowerCase().indexOf(value) > -1;
+    return record.indexOf(value) > -1;
   }
 
   function runRecordFilters(records, filters) {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4208

Special characters are removed from search term

![image](https://user-images.githubusercontent.com/290733/57151263-5b0d5d00-6dc8-11e9-8769-b0eebc92e22e.png)

Special characters are removed from records for comparison

![image](https://user-images.githubusercontent.com/290733/57151285-6bbdd300-6dc8-11e9-838f-bcc11637568f.png)
