### PR TITLE
Add support for computed fields

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -15,6 +15,7 @@ function DynamicList(id, data, container) {
   // Makes data and the component container available to Public functions
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
+  this.data.computedFields = this.data.computedFields || {};
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.queryOptions = {};
 
@@ -583,6 +584,11 @@ DynamicList.prototype.initialize = function() {
       return _this.connectToDataSource();
     })
     .then(function (records) {
+      _this.Utils.Records.addComputedFields({
+        records: records,
+        config: _this.data
+      });
+
       return Fliplet.Hooks.run('flListDataAfterGetData', {
         config: _this.data,
         id: _this.data.id,

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -18,6 +18,7 @@ function DynamicList(id, data, container) {
   // Makes data and the component container available to Public functions
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
+  this.data.computedFields = this.data.computedFields || {};
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.$overlay;
   this.queryOptions = {};
@@ -911,6 +912,11 @@ DynamicList.prototype.initialize = function() {
       return _this.connectToDataSource();
     })
     .then(function (records) {
+      _this.Utils.Records.addComputedFields({
+        records: records,
+        config: _this.data
+      });
+
       return Fliplet.Hooks.run('flListDataAfterGetData', {
         config: _this.data,
         id: _this.data.id,

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -19,6 +19,7 @@ function DynamicList(id, data, container) {
   // Makes data and the component container available to Public functions
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
+  this.data.computedFields = this.data.computedFields || {};
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.queryOptions = {};
 
@@ -733,6 +734,11 @@ DynamicList.prototype.initialize = function() {
       return _this.connectToDataSource();
     })
     .then(function (records) {
+      _this.Utils.Records.addComputedFields({
+        records: records,
+        config: _this.data
+      });
+
       return Fliplet.Hooks.run('flListDataAfterGetData', {
         config: _this.data,
         id: _this.data.id,

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -17,6 +17,7 @@ function DynamicList(id, data, container) {
   // Makes data and the component container available to Public functions
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
+  this.data.computedFields = this.data.computedFields || {};
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.queryOptions = {};
 
@@ -610,6 +611,11 @@ DynamicList.prototype.initialize = function() {
       return _this.connectToDataSource();
     })
     .then(function (records) {
+      _this.Utils.Records.addComputedFields({
+        records: records,
+        config: _this.data
+      });
+
       return Fliplet.Hooks.run('flListDataAfterGetData', {
         config: _this.data,
         id: _this.data.id,

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -14,6 +14,7 @@ function DynamicList(id, data, container) {
   // Makes data and the component container available to Public functions
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
+  this.data.computedFields = this.data.computedFields || {};
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.queryOptions = {};
 
@@ -352,6 +353,11 @@ DynamicList.prototype.initialize = function() {
       return _this.connectToDataSource();
     })
     .then(function (records) {
+      _this.Utils.Records.addComputedFields({
+        records: records,
+        config: _this.data
+      });
+
       return Fliplet.Hooks.run('flListDataAfterGetData', {
         config: _this.data,
         id: _this.data.id,

--- a/js/utils.js
+++ b/js/utils.js
@@ -824,7 +824,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     if (computedFieldClashes.length) {
       var clashedFields = computedFieldClashes.sort().join(', ');
-      console.warn('Computed field(s) "' + clashedFields + '" are already defined as a property for one or more records. All computed fields will overwrite existing properties. Use a different computed field name if you want to prevent the data from being overwritten');
+      console.warn('Computed field(s) "' + clashedFields + '" are already defined as a property for one or more records. All computed fields will overwrite existing properties. Use a different computed field name if you want to prevent the data from being overwritten.');
     }
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -824,7 +824,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     if (computedFieldClashes.length) {
       var clashedFields = computedFieldClashes.sort().join(', ');
-      console.warn('Computed field(s) "' + clashedFields + '" are already defined as a property. All computed fields will overwrite existing properties. Use a different computed field name if you want to prevent the data from being overwritten');
+      console.warn('Computed field(s) "' + clashedFields + '" are already defined as a property for one or more records. All computed fields will overwrite existing properties. Use a different computed field name if you want to prevent the data from being overwritten');
     }
   }
 


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4528

Computed properties will overwrite any existing properties. When this happens, a warning message will be shown to the user in developer console.

```
Computed field(s) "Foo, Bar" are already defined as a property for one or more records. All computed fields will overwrite existing properties. Use a different computed field name if you want to prevent the data from being overwritten.
```