### PR TITLE
Corrects record referencing when invalid image URLs are used

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -455,7 +455,7 @@ Fliplet.Registry.set('dynamicListUtils', function() {
             break;
           case 'url':
             if (!isValidImageUrl(record.data[config.userPhotoColumn])) {
-              records[index].data[config.userPhotoColumn] = '';
+              record.data[config.userPhotoColumn] = '';
             }
             break;
           default:


### PR DESCRIPTION
Prevents the LFD from not loading when an invalid image URL is used