### PR TITLE
Add border radius on the left when no images are used in the small card layout

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -653,7 +653,8 @@
 .new-small-card-list-container .small-card-list-text-wrapper {
   height: 100%;
   padding: 0 0 0 15px;
-  border-radius: 0 15px 15px 0;
+  border-top-right-radius: 15px;
+  border-bottom-right-radius: 15px;
   flex: 1;
   background-color: #ffffff;
   display: flex;
@@ -661,6 +662,11 @@
   justify-content: center;
   align-items: flex-start;
   position: relative;
+}
+
+.new-small-card-list-container .small-card-list-image.no-image + .small-card-list-text-wrapper {
+  border-top-left-radius: 15px;
+  border-bottom-left-radius: 15px;
 }
 
 .new-small-card-list-container .small-card-list-name {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4512#issuecomment-501676513

![image](https://user-images.githubusercontent.com/290733/59438109-bfb9cf80-8dea-11e9-82ca-b71107901603.png)
