### PR TITLE
Add support for specifying columns in filter queries

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1012,7 +1012,7 @@ DynamicList.prototype.checkIsToOpen = function(options) {
 DynamicList.prototype.prepareToSearch = function() {
   var _this = this;
 
-  if ( !_.hasIn(_this.pvSearchQuery, 'value') ) {
+  if (!_.get(_this.pvSearchQuery, 'value')) {
     return;
   }
 
@@ -1028,21 +1028,11 @@ DynamicList.prototype.prepareToSearch = function() {
 
 DynamicList.prototype.prepareToFilter = function() {
   var _this = this;
+  var filterSelectors = _this.Utils.Query.getFilterSelectors({ query: query });
 
-  if ( !_this.pvFilterQuery || !_.hasIn(_this.pvFilterQuery, 'value') ) {
-    return;
-  }
-
-  if (Array.isArray(_this.pvFilterQuery.value)) {
-    _this.pvFilterQuery.value.forEach(function(value) {
-      value = value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-      _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + value + '"]').addClass('mixitup-control-active');
-    });
-  } else {
-    _this.pvFilterQuery.value = _this.pvFilterQuery.value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-    _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + _this.pvFilterQuery.value + '"]').addClass('mixitup-control-active');
-  }
-
+  _this.$container.find(_.map(filterSelectors, function (selector) {
+    return '.hidden-filter-controls-filter' + selector;
+  }).join(',')).addClass('mixitup-control-active');
   _this.filterList();
 
   if (typeof _this.pvFilterQuery.hideControls !== 'undefined' && !_this.pvFilterQuery.hideControls) {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -3,7 +3,6 @@ function DynamicList(id, data, container) {
   var _this = this;
 
   this.flListLayoutConfig = window.flListLayoutConfig;
-
   this.layoutMapping = {
     'simple-list': {
       'base': 'templates.build.simple-list-base',
@@ -835,7 +834,7 @@ DynamicList.prototype.checkIsToOpen = function(options) {
 DynamicList.prototype.prepareToSearch = function() {
   var _this = this;
 
-  if ( !_.hasIn(_this.pvSearchQuery, 'value') ) {
+  if (!_.get(_this.pvSearchQuery, 'value')) {
     return;
   }
 
@@ -851,21 +850,11 @@ DynamicList.prototype.prepareToSearch = function() {
 
 DynamicList.prototype.prepareToFilter = function() {
   var _this = this;
+  var filterSelectors = _this.Utils.Query.getFilterSelectors({ query: query });
 
-  if ( !_this.pvFilterQuery || !_.hasIn(_this.pvFilterQuery, 'value') ) {
-    return;
-  }
-
-  if (Array.isArray(_this.pvFilterQuery.value)) {
-    _this.pvFilterQuery.value.forEach(function(value) {
-      value = value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-      _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + value + '"]').addClass('mixitup-control-active');
-    });
-  } else {
-    _this.pvFilterQuery.value = _this.pvFilterQuery.value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-    _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + _this.pvFilterQuery.value + '"]').addClass('mixitup-control-active');
-  }
-
+  _this.$container.find(_.map(filterSelectors, function (selector) {
+    return '.hidden-filter-controls-filter' + selector;
+  }).join(',')).addClass('mixitup-control-active');
   _this.filterList();
 
   if (typeof _this.pvFilterQuery.hideControls !== 'undefined' && !_this.pvFilterQuery.hideControls) {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -740,7 +740,7 @@ DynamicList.prototype.checkIsToOpen = function(options) {
 DynamicList.prototype.prepareToSearch = function() {
   var _this = this;
 
-  if ( !_.hasIn(_this.pvSearchQuery, 'value') ) {
+  if (!_.get(_this.pvSearchQuery, 'value')) {
     return;
   }
 
@@ -754,21 +754,11 @@ DynamicList.prototype.prepareToSearch = function() {
 
 DynamicList.prototype.prepareToFilter = function() {
   var _this = this;
+  var filterSelectors = _this.Utils.Query.getFilterSelectors({ query: query });
 
-  if ( !_this.pvFilterQuery || !_.hasIn(_this.pvFilterQuery, 'value') ) {
-    return;
-  }
-
-  if (Array.isArray(_this.pvFilterQuery.value)) {
-    _this.pvFilterQuery.value.forEach(function(value) {
-      value = value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-      _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + value + '"]').addClass('mixitup-control-active');
-    });
-  } else {
-    _this.pvFilterQuery.value = _this.pvFilterQuery.value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
-    _this.$container.find('.hidden-filter-controls-filter[data-toggle="' + _this.pvFilterQuery.value + '"]').addClass('mixitup-control-active');
-  }
-
+  _this.$container.find(_.map(filterSelectors, function (selector) {
+    return '.hidden-filter-controls-filter' + selector;
+  }).join(',')).addClass('mixitup-control-active');
   _this.filterList();
 
   if (typeof _this.pvFilterQuery.hideControls !== 'undefined' && !_this.pvFilterQuery.hideControls) {

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -7,7 +7,7 @@ function DynamicList(id, data, container) {
     'small-h-card': {
       'base': 'templates.build.small-h-card-base',
       'loop': 'templates.build.small-h-card-loop',
-      'detail': 'templates.build.small-h-card-detail',
+      'detail': 'templates.build.small-h-card-detail'
     }
   };
 

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -4,6 +4,25 @@
  * for prepopulating, prefiltering and opening an entry
  */
 Fliplet.Registry.set('dynamicListQueryParser', function() {
+  function splitQueryValues(input) {
+    var splitPattern = /\,\s?(?![^\\[]*\])/;
+    var testPattern = /^(?:\[[\w\W]*\])$/;
+
+    if (_.isNil(input)) {
+      return input;
+    }
+
+    return ('' + input).trim().split(splitPattern).map(function (str) {
+      str = str.trim();
+
+      if (!testPattern.test(str)) {
+        return str;
+      }
+
+      return _.compact(splitQueryValues(str.substring(1, str.length-1)));
+    });
+  }
+
   // we do not execute previousScreen like in the PV case so we don't open ourselves up to an xss attack
   this.previousScreen = Fliplet.Navigate.query['dynamicListPreviousScreen'] === 'true';
 
@@ -30,14 +49,12 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
 
   if (this.queryPreFilter) {
     // take the query parameters and parse them down to arrays
-    var prefilterColumnParts = this.pvPreFilterQuery.column ? this.pvPreFilterQuery.column.split(',') : [];
-    var prefilterLogicParts = this.pvPreFilterQuery.logic ? this.pvPreFilterQuery.logic.split(',') : [];
-    var prefilterValueParts = this.pvPreFilterQuery.value ? this.pvPreFilterQuery.value.split(',') : [];
+    var prefilterColumnParts = splitQueryValues(this.pvPreFilterQuery.column);
+    var prefilterLogicParts = splitQueryValues(this.pvPreFilterQuery.logic);
+    var prefilterValueParts = splitQueryValues(this.pvPreFilterQuery.value);
 
-    if (
-      prefilterColumnParts.length !== prefilterLogicParts.length ||
-      prefilterLogicParts.length !== prefilterValueParts.length
-    ) {
+    if (prefilterColumnParts.length !== prefilterLogicParts.length
+      || prefilterLogicParts.length !== prefilterValueParts.length) {
       this.pvPreFilterQuery = null;
       this.queryPreFilter = false;
       console.warn('Please supply an equal number of parameter to the dynamicListPrefilter filters.');
@@ -78,37 +95,46 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
     value: Fliplet.Navigate.query['dynamicListSearchValue']
   });
   this.querySearch = _(this.pvSearchQuery).size() > 0;
+
   if (this.querySearch) {
     // check if a comma separated list of columns were passed as column
-    var searchColumns = this.pvSearchQuery.column ? this.pvSearchQuery.column.split(',') : null;
-    this.pvSearchQuery.column = searchColumns && searchColumns.length ? searchColumns : this.pvSearchQuery.column;
+    this.pvSearchQuery.column = splitQueryValues(this.pvSearchQuery.column);
     this.data.searchEnabled = this.querySearch;
   } else {
     this.querySearch = null;
   }
 
   this.pvFilterQuery = _.pickBy({
+    column: Fliplet.Navigate.query['dynamicListFilterColumn'],
     value: Fliplet.Navigate.query['dynamicListFilterValue'],
     hideControls: Fliplet.Navigate.query['dynamicListFilterHideControls']
   });
   this.queryFilter = _(this.pvFilterQuery).size() > 0;
+
   if (this.queryFilter) {
-    // check if a comma separated list of columns were passed as column
-    var filterValues = this.pvFilterQuery.value ? this.pvFilterQuery.value.split(',') : null;
-    this.pvFilterQuery.value = filterValues && filterValues.length ? filterValues : this.pvFilterQuery.column;
+    // check if a comma separated list of columns/values were passed as column/value
+    this.pvFilterQuery.column = splitQueryValues(this.pvFilterQuery.column);
+    this.pvFilterQuery.value = splitQueryValues(this.pvFilterQuery.value);
+
+    if ((this.pvFilterQuery.column.length || this.pvFilterQuery.value.length)
+      && this.pvFilterQuery.column.length !== this.pvFilterQuery.value.length) {
+      this.pvFilterQuery.column = undefined;
+      this.pvFilterQuery.value = undefined;
+      this.queryFilter = false;
+      console.warn('Please supply an equal number of parameter to the dynamicListFilterColumn and dynamicListFilterValue.');
+    }
 
     // cast to boolean
-    this.pvFilterQuery.hideControls = this.pvFilterQuery.hideControls === 'true';
+    this.pvFilterQuery.hideControls = (this.pvFilterQuery.hideControls || '').toLowerCase() === 'true';
     this.data.filtersEnabled = this.queryFilter;
   } else {
     this.queryFilter = null;
   }
-  return (
-    this.previousScreen ||
-    this.queryGoBack ||
-    this.queryPreFilter ||
-    this.queryOpen ||
-    this.querySearch ||
-    this.queryFilter
-  );
+
+  return this.previousScreen
+    || this.queryGoBack
+    || this.queryPreFilter
+    || this.queryOpen
+    || this.querySearch
+    || this.queryFilter;
 });

--- a/js/utils.js
+++ b/js/utils.js
@@ -178,6 +178,43 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     return moment(new Date(date));
   }
 
+  function getFilterQuerySelectors(options) {
+    options = options || {};
+
+    var query = options.query || {};
+
+    if (!_.get(query, 'value', []).length) {
+      return [];
+    }
+
+    var selectors = [];
+
+    if (!Array.isArray(query.value)) {
+      query.value = [query.value];
+    }
+
+    if (_.get(query, 'column', []).length) {
+      // Select filters using on legacy column-specific methods
+      query.column.forEach(function (key, index) {
+        if (!Array.isArray(query.value[index])) {
+          query.value[index] = [query.value[index]];
+        }
+
+        query.value[index].forEach(function (value) {
+          selectors.push('[data-key="' + key + '"][data-value="' + value + '"]');
+        });
+      });
+    } else {
+      // Select filters using on legacy class-based methods
+      query.value.forEach(function(value) {
+        value = value.toLowerCase().replace(/[!@#\$%\^\&*\)\(\ ]/g,"-");
+        selectors.push('[data-toggle="' + value + '"]');
+      });
+    }
+
+    return selectors;
+  }
+
   function removeSymbols(str) {
     return ('' + str).replace(/[&\/\\#,+()$~%.`'‘’"“”:*?<>{}]+/g, '');
   }
@@ -878,6 +915,9 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     },
     Date: {
       moment: getMomentDate
+    },
+    Query: {
+      getFilterSelectors: getFilterQuerySelectors,
     },
     Record: {
       contains: recordContains,


### PR DESCRIPTION
Merging into `feat/filter-rebuild` for https://github.com/Fliplet/fliplet-studio/issues/4343

Ref. https://github.com/Fliplet/fliplet-studio/issues/4342 https://github.com/Fliplet/fliplet-studio/issues/4550

## Docs

https://github.com/Fliplet/fliplet-cli/pull/108

## Examples

```
dynamicListFilterColumn=Tags,Category&dynamicListFilterValue=[Foo,Buzz],Enterprise%20software
```

The queries above specify:

```js
(Tags.includes("Foo") && Tags.includes("Buzz") && Category === 'Enterprise')
```