### PR TITLE
Initial support for returning users to previously opened entries

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -87,7 +87,6 @@ DynamicList.prototype.attachObservers = function() {
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });
 
@@ -277,7 +276,6 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('keydown', function(e) {
       if (e.keyCode === 39) {
@@ -1685,8 +1683,9 @@ DynamicList.prototype.showDetails = function (id) {
 DynamicList.prototype.closeDetails = function() {
   // Function that closes the overlay
   var _this = this;
-
   var $overlay = $('#agenda-detail-overlay-' + _this.data.id);
+
+  Fliplet.Page.Context.remove('dynamicListOpenId');
   $overlay.removeClass('open');
   _this.$container.find('.agenda-feed-list-container').removeClass('overlay-open');
   $('body').removeClass('lock');

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -86,6 +86,7 @@ DynamicList.prototype.attachObservers = function() {
 
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
+      _this.closeDetails();
       Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -78,9 +78,16 @@ DynamicList.prototype.Utils = Fliplet.Registry.get('dynamicListUtils');
 
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
+
   // Attach your event listeners here
   $(window).resize(function() {
     _this.centerDate();
+  });
+
+  Fliplet.Hooks.on('beforePageView', function (options) {
+    if (options.addToHistory === false) {
+      Fliplet.Page.Context.remove('dynamicListOpenId');
+    }
   });
 
   _this.$container
@@ -232,6 +239,9 @@ DynamicList.prototype.attachObservers = function() {
         }
 
         _this.showDetails(entryId);
+        Fliplet.Page.Context.update({
+          dynamicListOpenId: entryId
+        });
       });
     })
     .on('click', '.agenda-detail-overlay-close', function() {
@@ -266,6 +276,7 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
+      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('keydown', function(e) {
       if (e.keyCode === 39) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -109,6 +109,7 @@ DynamicList.prototype.attachObservers = function() {
   // Attach your event listeners here
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
+      _this.closeDetails();
       Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -105,7 +105,14 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
 
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
+
   // Attach your event listeners here
+  Fliplet.Hooks.on('beforePageView', function (options) {
+    if (options.addToHistory === false) {
+      Fliplet.Page.Context.remove('dynamicListOpenId');
+    }
+  });
+
   _this.$container
     .on('click', '[data-lfd-back]', function() {
       var result;
@@ -216,6 +223,9 @@ DynamicList.prototype.attachObservers = function() {
         // find the element to expand and expand it
         if (_this.allowClick) {
           _this.showDetails(entryId);
+          Fliplet.Page.Context.update({
+            dynamicListOpenId: entryId
+          });
         }
       });
     })
@@ -251,6 +261,7 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
+      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.list-search-icon .fa-sliders', function() {
       var $elementClicked = $(this);

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -110,7 +110,6 @@ DynamicList.prototype.attachObservers = function() {
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });
 
@@ -262,7 +261,6 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.list-search-icon .fa-sliders', function() {
       var $elementClicked = $(this);
@@ -1894,6 +1892,7 @@ DynamicList.prototype.closeDetails = function() {
   // Function that closes the overlay
   var _this = this;
 
+  Fliplet.Page.Context.remove('dynamicListOpenId');
   _this.$overlay.removeClass('open');
   _this.$container.find('.new-news-feed-list-container').removeClass('overlay-open');
   $('body').removeClass('lock');

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -100,6 +100,7 @@ DynamicList.prototype.attachObservers = function() {
 
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
+      _this.closeDetails();
       Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -98,6 +98,12 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
 
+  Fliplet.Hooks.on('beforePageView', function (options) {
+    if (options.addToHistory === false) {
+      Fliplet.Page.Context.remove('dynamicListOpenId');
+    }
+  });
+
   _this.$container
     .on('click', '[data-lfd-back]', function() {
       var result;
@@ -192,6 +198,9 @@ DynamicList.prototype.attachObservers = function() {
         }
 
         _this.showDetails(entryId);
+        Fliplet.Page.Context.update({
+          dynamicListOpenId: entryId
+        });
       });
     })
     .on('click', '.simple-list-detail-overlay-close', function() {
@@ -226,6 +235,7 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
+      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.list-search-icon .fa-sliders', function() {
       var $elementClicked = $(this);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -101,7 +101,6 @@ DynamicList.prototype.attachObservers = function() {
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });
 
@@ -236,7 +235,6 @@ DynamicList.prototype.attachObservers = function() {
       }
 
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.list-search-icon .fa-sliders', function() {
       var $elementClicked = $(this);
@@ -1845,8 +1843,9 @@ DynamicList.prototype.showDetails = function (id) {
 DynamicList.prototype.closeDetails = function() {
   // Function that closes the overlay
   var _this = this;
-
   var $overlay = $('#simple-list-detail-overlay-' + _this.data.id);
+
+  Fliplet.Page.Context.remove('dynamicListOpenId');
   $('body').removeClass('lock');
   $overlay.removeClass('open');
   _this.$container.find('.simple-list-container').removeClass('overlay-open');

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -107,7 +107,6 @@ DynamicList.prototype.attachObservers = function() {
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });
 
@@ -1603,8 +1602,9 @@ DynamicList.prototype.showDetails = function (id) {
 DynamicList.prototype.closeDetails = function() {
   // Function that closes the overlay
   var _this = this;
-
   var $overlay = $('#small-card-detail-overlay-' + _this.data.id);
+
+  Fliplet.Page.Context.remove('dynamicListOpenId');
   $overlay.removeClass('open');
   _this.$container.find('.new-small-card-list-container').removeClass('overlay-open');
 

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -106,6 +106,7 @@ DynamicList.prototype.attachObservers = function() {
   // Attach your event listeners here
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
+      _this.closeDetails();
       Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -102,7 +102,14 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
 
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
+
   // Attach your event listeners here
+  Fliplet.Hooks.on('beforePageView', function (options) {
+    if (options.addToHistory === false) {
+      Fliplet.Page.Context.remove('dynamicListOpenId');
+    }
+  });
+
   _this.$container
     .on('click', '[data-lfd-back]', function() {
       var result;
@@ -192,6 +199,9 @@ DynamicList.prototype.attachObservers = function() {
         _this.expandElement(_this.directoryDetailWrapper, _this.modifiedProfileData[0].id);
       } else {
         _this.showDetails(_this.modifiedProfileData[0].id);
+        Fliplet.Page.Context.update({
+          dynamicListOpenId: entryId
+        });
       }
 
       Fliplet.Analytics.trackEvent({
@@ -243,6 +253,10 @@ DynamicList.prototype.attachObservers = function() {
         } else if (_this.allowClick && $(window).width() >= 640) {
           _this.showDetails(entryId);
         }
+
+        Fliplet.Page.Context.update({
+          dynamicListOpenId: entryId
+        });
       });
     })
     .on('click', '.small-card-detail-overlay-close', function(event) {
@@ -283,6 +297,8 @@ DynamicList.prototype.attachObservers = function() {
       } else {
         _this.closeDetails();
       }
+
+      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.list-search-icon .fa-sliders', function() {
       var $elementClicked = $(this);

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -74,7 +74,6 @@ DynamicList.prototype.attachObservers = function() {
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
       _this.closeDetails();
-      Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });
 
@@ -833,8 +832,9 @@ DynamicList.prototype.showDetails = function (id) {
 DynamicList.prototype.closeDetails = function() {
   // Function that closes the overlay
   var _this = this;
-
   var $overlay = $('#small-h-card-detail-overlay-' + _this.data.id);
+
+  Fliplet.Page.Context.remove('dynamicListOpenId');
   $overlay.removeClass('open');
   _this.$container.find('.new-small-h-card-list-container').removeClass('overlay-open');
 

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -73,6 +73,7 @@ DynamicList.prototype.attachObservers = function() {
   // Attach your event listeners here
   Fliplet.Hooks.on('beforePageView', function (options) {
     if (options.addToHistory === false) {
+      _this.closeDetails();
       Fliplet.Page.Context.remove('dynamicListOpenId');
     }
   });

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -69,7 +69,14 @@ DynamicList.prototype.Utils = Fliplet.Registry.get('dynamicListUtils');
 
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
+
   // Attach your event listeners here
+  Fliplet.Hooks.on('beforePageView', function (options) {
+    if (options.addToHistory === false) {
+      Fliplet.Page.Context.remove('dynamicListOpenId');
+    }
+  });
+
   _this.$container
     .on('click', '.small-h-card-list-detail-button a', function() {
       var _that = $(this);
@@ -127,6 +134,7 @@ DynamicList.prototype.attachObservers = function() {
           _this.openLinkAction(entryId);
           return;
         }
+
         // find the element to expand and expand it
         if (_this.allowClick && $(window).width() < 640) {
           _this.directoryDetailWrapper = _that.find('.small-h-card-list-detail-wrapper');
@@ -134,6 +142,10 @@ DynamicList.prototype.attachObservers = function() {
         } else if (_this.allowClick && $(window).width() >= 640) {
           _this.showDetails(entryId);
         }
+
+        Fliplet.Page.Context.update({
+          dynamicListOpenId: entryId
+        });
       });
     })
     .on('click', '.small-h-card-detail-overlay-close', function(event) {
@@ -175,6 +187,8 @@ DynamicList.prototype.attachObservers = function() {
       } else {
         _this.closeDetails();
       }
+
+      Fliplet.Page.Context.remove('dynamicListOpenId');
     })
     .on('click', '.dynamic-list-add-item', function() {
       var options = {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/3263

This implementation needs to be updated after `Fliplet.Page.Context.push()` and `.pull()` are added to prevent the navstack from being overwritten.