### PR TITLE
Bookmark - Not at the right position

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -721,9 +721,8 @@
 
 @media screen and (min-width: 640px) {
   .small-card-list-detail-content-wrapper .small-card-bookmark-holder {
-    top: -40px;
-    left: auto;
-    right: -30px;
+    top: -35px;
+    padding: 0px;
   }
 }
 


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior**:
The issue was that the bookmark icon on tablets and desktop was aligned to the right.  
Now on all devices, bookmark aligned to the left.

ref https://github.com/Fliplet/fliplet-studio/issues/4123.

<img width="351" alt="Bookmark-demo-3" src="https://user-images.githubusercontent.com/52824207/61956056-05121500-afc5-11e9-9757-243836672670.png">
<img width="822" alt="Bookmark-demo-2" src="https://user-images.githubusercontent.com/52824207/61955920-b9f80200-afc4-11e9-93a5-4444c2086729.png">
<img width="461" alt="Bookmark-demo-1" src="https://user-images.githubusercontent.com/52824207/61955921-b9f80200-afc4-11e9-83b3-c0d85d14bfcc.png">

