### PR TITLE
Horizontal scroll bar overlaps filters items 

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -296,7 +296,7 @@
 }
 
 .new-news-feed-list-container .hidden-filter-controls-content {
-  padding-bottom: 25px;
+  padding-bottom: 15px;
 }
 
 .new-news-feed-list-container .hidden-filter-controls-search {
@@ -453,6 +453,7 @@
 .new-news-feed-list-container .hidden-filter-controls-filter-wrapper {
   padding: 0 15px;
   overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
 }
 
@@ -461,7 +462,7 @@
   border: 1px solid #e5e5e5;
   border-radius: 20px;
   padding: 8px 15px;
-  margin: 0 5px 0 0;
+  margin: 0 5px 7px 0;
   font-size: 14px;
 }
 

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -302,7 +302,7 @@
 }
 
 .hidden-filter-controls-content {
-  padding-bottom: 25px;
+  padding-bottom: 15px;
 }
 
 .hidden-filter-controls-search {
@@ -459,6 +459,7 @@
 .hidden-filter-controls-filter-wrapper {
   padding: 0 15px;
   overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
 }
 
@@ -467,7 +468,7 @@
   border: 1px solid #e5e5e5;
   border-radius: 20px;
   padding: 8px 15px;
-  margin: 0 5px 0 0;
+  margin: 0 5px 7px 0;
   font-size: 14px;
 }
 

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -353,7 +353,7 @@
 }
 
 .new-small-card-list-container .hidden-filter-controls-content {
-  padding-bottom: 15px;
+  padding-bottom: 10px;
 }
 
 .new-small-card-list-container .hidden-filter-controls-search {
@@ -512,6 +512,7 @@
 .new-small-card-list-container .hidden-filter-controls-filter-wrapper {
   padding: 0 15px;
   overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
 }
 
@@ -520,7 +521,7 @@
   border: 1px solid #e5e5e5;
   border-radius: 20px;
   padding: 8px 15px;
-  margin: 0 5px 0 0;
+  margin: 0 5px 7px 0;
   font-size: 14px;
 }
 

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1511,11 +1511,9 @@ DynamicList.prototype.getActiveFilters = function () {
 
 DynamicList.prototype.calculateFiltersHeight = function($el) {
   $el.find('.hidden-filter-controls').each(function () {
-    var $controls = $(this);
-    var totalHeight = $controls.find('.hidden-filter-controls-content').height();
-    $controls.animate({
-      height: totalHeight,
-    }, 200);
+    $(this).animate({
+      height: '100%',
+    }, 200);   
   });
 }
 

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1245,11 +1245,9 @@ DynamicList.prototype.getActiveFilters = function () {
 
 DynamicList.prototype.calculateFiltersHeight = function($el) {
   $el.find('.hidden-filter-controls').each(function () {
-    var $controls = $(this);
-    var totalHeight = $controls.find('.hidden-filter-controls-content').height();
-    $controls.animate({
-      height: totalHeight,
-    }, 200);
+    $(this).animate({
+      height: '100%',
+    }, 200);   
   });
 }
 

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1213,11 +1213,9 @@ DynamicList.prototype.getActiveFilters = function () {
 
 DynamicList.prototype.calculateFiltersHeight = function($el) {
   $el.find('.hidden-filter-controls').each(function () {
-    var $controls = $(this);
-    var totalHeight = $controls.find('.hidden-filter-controls-content').height();
-    $controls.animate({
-      height: totalHeight,
-    }, 200);
+    $(this).animate({
+      height: '100%',
+    }, 200);   
   });
 }
 


### PR DESCRIPTION
@tonytlwu @squallstar 

**Fixed behavior**:
The issue was that the horizontal scroll bar was overlapping filters items when there are many filters value in one column.

Changed filter animation that used to be there. It used to calculate dynamically filter block height, but in Safari on the first time opening the height calculated incorrectly. Now it isn't calculating a filter block height but making it 100%. This is what helped to display it right in Safari.

ref https://github.com/Fliplet/fliplet-studio/issues/4713

![horizontal-scroll-bar-fix](https://user-images.githubusercontent.com/52824207/61957149-43a8cf00-afc7-11e9-9eaf-7b9426169ba3.gif)

