### PR TITLE
Disabling bookmark leaves a blank space

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -643,9 +643,14 @@
 }
 
 .agenda-item-bookmark.more-buttons .agenda-item-bookmark-holder {
-  display: flex;
+  display: none;
   align-items: center;
   min-width: 56px;
+}
+
+.agenda-item-bookmark.more-buttons .agenda-item-bookmark-holder.not-bookmarked,
+.agenda-item-bookmark.more-buttons .agenda-item-bookmark-holder.bookmarked {
+  display: flex;
 }
 
 .agenda-item-bookmark.more-buttons .agenda-item-bookmark-holder .bookmark-wrapper span {


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior**:
The bookmark div is displayed even if the bookmark feature is disabled.

Changed default state of the bookmark div to display none, and added the new CSS rule which giving display flex when this feature is enabled.

ref https://github.com/Fliplet/fliplet-studio/issues/4291

![bookmark-blank-div-fix](https://user-images.githubusercontent.com/52824207/62027410-51886b00-b1e6-11e9-8485-d62f9417209f.gif)


