### PR TITLE
Prevent configuration loss if the interface is saved before everything has loaded

### DIFF
--- a/js/interface-lists.js
+++ b/js/interface-lists.js
@@ -512,6 +512,7 @@ function attahObservers() {
   Fliplet.Widget.onSaveRequest(function () {
     if (!dynamicLists.isLoaded) {
       Fliplet.Widget.complete();
+      return;
     }
     $('form').submit();
   });

--- a/js/interface-lists.js
+++ b/js/interface-lists.js
@@ -282,7 +282,7 @@ function attahObservers() {
             value: widgetData.userAdminColumn,
             field: '#select_user_admin'
           });
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -330,7 +330,7 @@ function attahObservers() {
           if (!widgetData.userNameFields && !widgetData.userNameFields.length) {
             errors.push('#user-name-column-fields-tokenfield');
           }
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -369,11 +369,11 @@ function attahObservers() {
             value: widgetData.userEmailColumn,
             field: '#select_user_email'
           });
-          
+
           if (!widgetData.userNameFields && !widgetData.userNameFields.length) {
             errors.push('#user-name-column-fields-tokenfield');
           }
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -408,7 +408,7 @@ function attahObservers() {
             value: widgetData.pollColumn,
             field: '#select_poll_data'
           });
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -443,7 +443,7 @@ function attahObservers() {
             value: widgetData.pollColumn,
             field: '#select_survey_data'
           });
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -478,7 +478,7 @@ function attahObservers() {
             value: widgetData.pollColumn,
             field: '#select_questions_data'
           });
-          
+
           values.forEach(function(field) {
             if (!validate(field.value)) {
               errors.push(field.field);
@@ -510,9 +510,10 @@ function attahObservers() {
   });
 
   Fliplet.Widget.onSaveRequest(function () {
-    if (dynamicLists.isLoaded) {
-      $('form').submit();
+    if (!dynamicLists.isLoaded) {
+      Fliplet.Widget.complete();
     }
+    $('form').submit();
   });
 }
 

--- a/js/interface-lists.js
+++ b/js/interface-lists.js
@@ -510,7 +510,9 @@ function attahObservers() {
   });
 
   Fliplet.Widget.onSaveRequest(function () {
-    $('form').submit();
+    if (dynamicLists.isLoaded) {
+      $('form').submit();
+    }
   });
 }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -84,6 +84,7 @@ var DynamicLists = (function() {
     }, configuration);
     _this.widgetId = configuration.id;
 
+    _this.isLoaded = false;
     $('.layouts-flex').html(layoutsTemplate(listLayouts));
 
     _this.attachListeners();
@@ -659,6 +660,7 @@ var DynamicLists = (function() {
           return _this.loadData();
         })
         .then(function() {
+          _this.isLoaded = true;
           _this.initializeFilterSortable();
           _this.initializeSortSortable();
         });


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior**:
When clicking on the Save & Close button before all data is loaded, the component is saving empty data. 

Added variable _this.isLoaded which is false by default, and its value changes to true when data is loaded. Added check to Fliplet.Widget.onSaveRequest which is allowing to save component only when data is loaded.

ref https://github.com/Fliplet/fliplet-studio/issues/4370

![save-before-load](https://user-images.githubusercontent.com/52824207/62050518-0e47ef80-b21a-11e9-84be-76ab5249fcdd.gif)