### PR TITLE
Horizontal cards are not center-aligned on desktop and tablet screens

### DIFF
--- a/css/layout-css/small-h-card-style.upload.css
+++ b/css/layout-css/small-h-card-style.upload.css
@@ -31,6 +31,7 @@
 
 .new-small-h-card-list-container.ready .small-h-card-list-wrapper {
   display: flex;
+  justify-content: center;
 }
 
 .lock .new-small-h-card-list-container .small-h-card-list-wrapper {


### PR DESCRIPTION
@tonytlwu @squallstar 

Fixed behavior:
Horizontal cards weren't center-aligned on desktop and tablet screens.

Added justify-content center for the component main block.

ref https://github.com/Fliplet/fliplet-studio/issues/4213

![Horizontal-cards-wasn_t-center-aligned](https://user-images.githubusercontent.com/53430352/62199502-45d6a900-b38c-11e9-8446-c958036e7f15.gif)