### PR TITLE
Vertical aligned close icon.

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1218,6 +1218,7 @@
 }
 
 .fa-times-thin {
+  padding-top: 1px;
   padding-bottom: 3px;
 }
 


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4773

## Description
Vertical aligned close icon. By adding padding-top.

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/63429614-35619d80-c423-11e9-9695-bcde9c4a8bc1.png)

## Backward compatibility

This change is fully backward compatible.