### PR TITLE
Fixed agenda layout so it doesn't overlap the menu bar now in IE 11.

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -16,7 +16,7 @@
   bottom: 15px;
   bottom: calc(15px + env(safe-area-inset-bottom));
   right: 15px;
-  z-index: 11;
+  z-index: 9;
   cursor: pointer;
   width: 65px;
   height: 65px;
@@ -100,7 +100,7 @@
   display: flex;
   padding: 16px 0 10px 0;
   background-color: #ffffff;
-  z-index: 12;
+  z-index: 9;
 }
 
 .fl-with-top-menu .new-agenda-list-container .agenda-date-selector {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4867

## Description
Change z-index for agenda LFD layout, so it's didn't overlaps the menu bar in IE 11.
Done the same thing for the bookmark button, which overlaps the menu bar.

## Screenshots/screencasts

IE 11.1.18362.0
![image](https://user-images.githubusercontent.com/53430352/63584819-69b19700-c5a6-11e9-835b-b1e328bd0f11.png)

Edge 18.18362
![image](https://user-images.githubusercontent.com/53430352/63584778-543c6d00-c5a6-11e9-86f9-fcba301c1efd.png)

Chrome 76.0.3809.100
![image](https://user-images.githubusercontent.com/53430352/63584852-7a620d00-c5a6-11e9-9f45-70cd76bc3e12.png)

## Backward compatibility

This change is fully backward compatible.


