### PR TITLE
Prevents extra tag being added when configuring filter and search 

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1214,6 +1214,7 @@ var DynamicLists = (function() {
       _this.loadTokenFields();
     },
     removeFocusFromTokenInput: function () {
+      $('input.token-input.ui-autocomplete-input').val('');
       $('input.token-input.ui-autocomplete-input').blur();
     },
     handleTokensSelection: function () {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4953

## Description
Removed extra tag from filter and search

## Screenshots/screencasts
![issue-4953](https://user-images.githubusercontent.com/53430352/64612777-4b88cb00-d3dd-11e9-8b65-ad45bcae3a69.gif)

## Backward compatibility

This change is fully backward compatible.