### PR TITLE
Adds Handlebars helper for formatting CSV before printing

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -62,6 +62,14 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       return getMomentDate(date).format('DD MMMM YYYY');
     });
 
+    Handlebars.registerHelper('formatCSV', function (context) {
+      if (!context) {
+        return '';
+      }
+
+      return splitByCommas(context).join(', ');
+    });
+
     Handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
       switch (operator) {
         case '==':


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4982

Documentation for the new `formatCSV` Handlebars helper:

> `formatCSV` ensures that `"` characters are removed if the input is a CSV that contains `"` characters due to `,` being used in a value, e.g. `"Washington, D.C.", New York` will be formatted into `Washington, D.C., New York`.
