### PR TITLE
Removed ability to create custom tags in filter and search fields

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1186,7 +1186,7 @@ var DynamicLists = (function() {
       $('.search-fields').html(tokenField({
         name: 'search-column-fields',
         id: 'search-column-fields-tokenfield',
-        createTokensOnBlur: true
+        createTokensOnBlur: false
       }));
       $('#search-column-fields-tokenfield').tokenfield('destroy').tokenfield({
         autocomplete: {
@@ -1194,12 +1194,12 @@ var DynamicLists = (function() {
           delay: 100
         },
         showAutocompleteOnFocus: true,
-        createTokensOnBlur: true
+        createTokensOnBlur: false
       });
       $('.filter-fields').html(tokenField({
         name: 'filter-column-fields',
         id: 'filter-column-fields-tokenfield',
-        createTokensOnBlur: true
+        createTokensOnBlur: false
       }));
       $('#filter-column-fields-tokenfield').tokenfield('destroy').tokenfield({
         autocomplete: {
@@ -1207,14 +1207,13 @@ var DynamicLists = (function() {
           delay: 100
         },
         showAutocompleteOnFocus: true,
-        createTokensOnBlur: true
+        createTokensOnBlur: false
       });
 
       _this.handleTokensSelection();
       _this.loadTokenFields();
     },
     removeFocusFromTokenInput: function () {
-      $('input.token-input.ui-autocomplete-input').val('');
       $('input.token-input.ui-autocomplete-input').blur();
     },
     handleTokensSelection: function () {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4953

## Description
Removed ability to create custom tags in filter and search fields

## Screenshots/screencasts
![issue-4953-Fix](https://user-images.githubusercontent.com/53430352/64786157-85d9a000-d576-11e9-9aaf-20745f28617b.gif)

## Backward compatibility

This change is fully backward compatible.