### PR TITLE
Aligned close icons for native devices. 

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -140,3 +140,8 @@
     }
   }
 }
+
+/* For native devices */
+.native .fa-times-thin {
+  padding-top: 4px;
+} 

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1220,13 +1220,3 @@
     display: none;
   }
 }
-
-.fa-times-thin {
-  padding-top: 1px;
-  padding-bottom: 3px;
-}
-
-.fa-times-thin::before {
-  content: '\00d7';
-}
-


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4773

## Description
Aligned close icons for native devices. 

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/65038441-a465df80-d958-11e9-8b5d-2d4d64433ec8.png)

## Backward compatibility

This change is fully backward compatible.