### PR TITLE
Added different padding's to Android and iOS native devices

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -146,6 +146,6 @@
   padding-top: 5px;
 }
 
-.native.iphonex .fa-times-thin {
+.native.ios .fa-times-thin {
   padding-top: 3px;
 } 

--- a/css/build.css
+++ b/css/build.css
@@ -142,6 +142,10 @@
 }
 
 /* For native devices */
-.native .fa-times-thin {
-  padding-top: 4px;
+.native.android .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.iphonex .fa-times-thin {
+  padding-top: 3px;
 } 


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4773

## Description
Added different padding's to Android and iOS devices

## Screenshots/screencasts
iOS 12
![iOS closeIcon](https://user-images.githubusercontent.com/53430352/65150243-6803b380-da2c-11e9-8afd-164d8c3bdbaa.jpg)

Android 9
![Screenshot_20190918-155336](https://user-images.githubusercontent.com/53430352/65150324-95506180-da2c-11e9-9218-3181b0b1c453.png)


## Backward compatibility

This change is fully backward compatible.