### PR TITLE
Stop removing image URLs when they don't match HTTP URL or Base 64 patterns

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -170,7 +170,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     // Validate thumbnail against URL and Base64 patterns
     if (!Static.RegExp.httpUrl.test(url) && !Static.RegExp.base64Image.test(url)) {
-      return '';
+      return url;
     }
 
     return Fliplet.Media.authenticate(url);

--- a/js/utils.js
+++ b/js/utils.js
@@ -173,7 +173,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       return url;
     }
 
-    return Fliplet.Media.authenticate(url);
+    return new Handlebars.SafeString(Fliplet.Media.authenticate(url));
   }
 
   function getMomentDate(date) {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/5012