### PR TITLE
Image data field now has field type set as image

### DIFF
--- a/js/default-configs/layouts-config.js
+++ b/js/default-configs/layouts-config.js
@@ -341,6 +341,14 @@ window.flListLayoutConfig = {
         column: 'Category'
       }
     ],
-    'showSummaryFieldsInDetailView': true
+    'showSummaryFieldsInDetailView': true,
+    'detail-fields': [
+      {
+        id: 'wWkqeYGN',
+        location: 'Image',
+        type: 'image',
+        column: 'Image'
+      }
+    ]
   }
 }


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4969

## Description
Added image data-field in image layouts.

## Screenshots/screencasts
<img width="939" alt="Dynamic demo" src="https://user-images.githubusercontent.com/52824207/66299314-ee106d00-e8fb-11e9-9ef0-eb07ba9de8da.png">

## Backward compatibility
This change is fully backward compatible.

## Notes
Image Data Field now has Field label "No label" compared to others "Column name as label". Should we do anything about it?
<img width="862" alt="Dynamic demo 2" src="https://user-images.githubusercontent.com/52824207/66300002-38461e00-e8fd-11e9-860a-49f2458e6753.png">
