### PR TITLE
In the "Username data field" it is impossible to add a not existing tag, to select the same column multiple times and it is now clickable after selecting column.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1255,9 +1255,10 @@ var DynamicLists = (function() {
           delay: 100
         },
         showAutocompleteOnFocus: true,
-        createTokensOnBlur: true
+        createTokensOnBlur: false
       });
 
+      _this.handleTokensSelection();
       _this.loadUserTokenFields();
     },
     getColumns: function(dataSourceId) {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4991
Fliplet/fliplet-studio#4992
Fliplet/fliplet-studio#4994

## Description
Used already written code for Search and Filter fields. Disabled creation tokens on blur.

## Screenshots/screencasts
![dynamic demo video](https://user-images.githubusercontent.com/52824207/66311087-51a79400-e916-11e9-933f-6a8a3df76501.gif)

## Backward compatibility
This change is fully backward compatible.