### PR TITLE
Fixed icon position for iOS devices

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -147,7 +147,7 @@
 }
 
 .native.ios .fa-times-thin {
-  padding-top: 3px;
+  padding-top: 1px;
 }
 
 .mode-interact [data-dynamic-lists-id] {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4773

## Description
Fixed icon position for iOS devices

## Screenshots/screencasts
![iosIcon](https://user-images.githubusercontent.com/53430352/67019533-7c0f0380-f105-11e9-8707-957d0afc94f6.jpg)


## Backward compatibility

This change is fully backward compatible.