### PR TITLE
User is now able to edit messages in News Feed layout

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2372,6 +2372,12 @@ DynamicList.prototype.saveComment = function(entryId, commentId, value) {
     return comment.id === commentId;
   });
 
+  if (entryComments) {
+    commentData = _.find(entryComments, function(comment) {
+      return comment.id === commentId;
+    });
+  }
+
   if (commentData) {
     commentData.data.settings.text = value;
     _this.replaceComment(commentId, commentData, 'temp');


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5085

## Description
Apparently this piece of code was not added as it was in a simple-list layout. This caused entryComments to be undefined. Now works as expected.

## Screenshots/screencasts
![Edit demo](https://user-images.githubusercontent.com/52824207/67194784-73b61180-f400-11e9-9eda-41ec5f29bd45.gif)

## Backward compatibility
This change is fully backward compatible.