### PR TITLE
Empty comments (or only spaces) will be filtered and not get rendered to UI

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1988,13 +1988,16 @@ DynamicList.prototype.getEntryComments = function(options) {
         return instance.query({
           allowGrouping: true,
           where: {
-            content: content
+            content: content,
+            settings: {
+              text: { $regex: '[^\s]+' }
+            }
           }
         });
       })
       .then(function(entries) {
         var filteredEntries = _.filter(entries, function(entry) {
-          return entry.data.settings.text.trim();
+          return _.get(entry, 'data.settings.text', '').trim();
         });
         record.comments = filteredEntries;
         record.commentCount = filteredEntries.length;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1992,9 +1992,12 @@ DynamicList.prototype.getEntryComments = function(options) {
           }
         });
       })
-      .then(function(entries){
-        record.comments = entries;
-        record.commentCount = entries.length;
+      .then(function(entries) {
+        var filteredEntries = _.filter(entries, function(entry) {
+          return entry.data.settings.text.trim();
+        });
+        record.comments = filteredEntries;
+        record.commentCount = filteredEntries.length;
       });
   }
 

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1996,11 +1996,8 @@ DynamicList.prototype.getEntryComments = function(options) {
         });
       })
       .then(function(entries) {
-        var filteredEntries = _.filter(entries, function(entry) {
-          return _.get(entry, 'data.settings.text', '').trim();
-        });
-        record.comments = filteredEntries;
-        record.commentCount = filteredEntries.length;
+        record.comments = entries;
+        record.commentCount = entries.length;
       });
   }
 

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1942,13 +1942,16 @@ DynamicList.prototype.getEntryComments = function(options) {
         return instance.query({
           allowGrouping: true,
           where: {
-            content: content
+            content: content,
+            settings: {
+              text: { $regex: '[^\s]+' }
+            }
           }
         });
       })
       .then(function(entries) {
         var filteredEntries = _.filter(entries, function(entry) {
-          return entry.data.settings.text.trim();
+          return _.get(entry, 'data.settings.text', '').trim();
         });
         record.comments = filteredEntries;
         record.commentCount = filteredEntries.length;

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1950,11 +1950,8 @@ DynamicList.prototype.getEntryComments = function(options) {
         });
       })
       .then(function(entries) {
-        var filteredEntries = _.filter(entries, function(entry) {
-          return _.get(entry, 'data.settings.text', '').trim();
-        });
-        record.comments = filteredEntries;
-        record.commentCount = filteredEntries.length;
+        record.comments = entries;
+        record.commentCount = entries.length;
       });
   }
 

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1946,9 +1946,12 @@ DynamicList.prototype.getEntryComments = function(options) {
           }
         });
       })
-      .then(function(entries){
-        record.comments = entries;
-        record.commentCount = entries.length;
+      .then(function(entries) {
+        var filteredEntries = _.filter(entries, function(entry) {
+          return entry.data.settings.text.trim();
+        });
+        record.comments = filteredEntries;
+        record.commentCount = filteredEntries.length;
       });
   }
 


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5084

## Description
Added filter to left out empty comments.

## Screenshots/screencasts
![filter demo ](https://user-images.githubusercontent.com/52824207/67410208-71041980-f5c4-11e9-87ba-8574bc69df9d.gif)

## Backward compatibility
This change is fully backward compatible.