### PR TITLE
Edited comments now updated according to its ID

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2393,6 +2393,7 @@ DynamicList.prototype.saveComment = function(entryId, commentId, value) {
       return instance.update({
         settings: commentData.data.settings
       }, {
+        id: commentId,
         where: {
           content: content
         }

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2393,10 +2393,7 @@ DynamicList.prototype.saveComment = function(entryId, commentId, value) {
       return instance.update({
         settings: commentData.data.settings
       }, {
-        id: commentId,
-        where: {
-          content: content
-        }
+        id: commentId
       });
     })
     .then(function() {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2347,6 +2347,7 @@ DynamicList.prototype.saveComment = function(entryId, commentId, value) {
       return instance.update({
         settings: commentData.data.settings
       }, {
+        id: commentId,
         where: {
           content: content
         }

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2347,10 +2347,7 @@ DynamicList.prototype.saveComment = function(entryId, commentId, value) {
       return instance.update({
         settings: commentData.data.settings
       }, {
-        id: commentId,
-        where: {
-          content: content
-        }
+        id: commentId
       });
     })
     .then(function() {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5085

## Description
The bug occurred because editing comments was updating the last comment. Now it updates comment by id.

## Screenshots/screencasts
![editing comment demo](https://user-images.githubusercontent.com/52824207/67667476-93a48280-f976-11e9-9794-84d6fe51abf4.gif)

## Backward compatibility
This change is fully backward compatible.