### PR TITLE
Aligned close icon for Firefox, Edge and Android 9 Chrome

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -153,3 +153,25 @@
 .mode-interact [data-dynamic-lists-id] {
   min-height: 32px;
 }
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/build.css
+++ b/css/build.css
@@ -168,6 +168,11 @@
     padding-top: 2px;
     padding-bottom: 5px;
   }
+
+  .no-windows .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
 }
 
 /* For Android Chrome browser*/


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4773

## Description
Aligned close icon for Firefox, Edge and Android 9 Chrome.

## Screenshots/screencasts
Android 9 Chrome
![Android9 Chrome](https://user-images.githubusercontent.com/53430352/68134187-6b92c180-ff2a-11e9-8589-6336041f26d1.jpg)

MS Edge
![image](https://user-images.githubusercontent.com/53430352/68135333-27a0bc00-ff2c-11e9-9a2b-dcbe23972b0e.png)


Firefox
![Firefox](https://user-images.githubusercontent.com/53430352/68134225-7baaa100-ff2a-11e9-92f6-f38909960dc2.png)

## Backward compatibility

This change is fully backward compatible.