### PR TITLE
Simple list description in IE11 will look like in other browsers

### DIFF
--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -556,6 +556,7 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  height: 4.4em;
 }
 
 .simple-list-item .list-item-title {


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5030

## Description
Simple list description in IE11 will look like in other browsers

## Screenshots/screencasts
![issue 5030](https://user-images.githubusercontent.com/53430352/68388576-a59dd680-0169-11ea-9317-7e5ba720a9d2.png)


## Backward compatibility

This change is fully backward compatible.