### PR TITLE
Long words now not going beyond the edge of the screen

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -436,6 +436,10 @@
   line-height: 1;
 }
 
+.new-agenda-list-container .slide-over .agenda-item-inner-content .agenda-item-content-holder {
+  width: calc(100% - 60px);
+}
+
 .new-agenda-list-container .slide-over .agenda-item-inner-content h2.agenda-item-title,
 .agenda-detail-overlay .agenda-item-inner-content h2.agenda-item-title {
   position: relative;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5238

## Description
Added fixed width to the agenda-item-content-holder.

## Screenshots/screencasts
<img width="366" alt="content demo" src="https://user-images.githubusercontent.com/52824207/68947392-0a86ab80-07be-11ea-93ed-d03db21046c6.png">

## Backward compatibility
This change is fully backward compatible.