### PR TITLE
Show clipped description in simple list for IE11

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -10,7 +10,9 @@ $('[data-dynamic-lists-id]').each(function(){
 
   if (data.layout === 'simple-list' || data.layout === 'news-feed') {
     var showLines = Modernizr.ie11 ? 4 : 3;
-    var descriptionSelector = data.layout === 'simple-list' ? '.list-item-description' : '.news-feed-item-description';
+    var descriptionSelector = data.layout === 'simple-list'
+      ? '.list-item-description'
+      : '.news-feed-item-description';
     var awaitForDom = setInterval(function() {
       if ($(descriptionSelector).length) {
         clearInterval(awaitForDom);

--- a/js/build.js
+++ b/js/build.js
@@ -17,6 +17,7 @@ $('[data-dynamic-lists-id]').each(function(){
       if ($(descriptionSelector).length) {
         clearInterval(awaitForDom);
         var descriptions = document.querySelectorAll(descriptionSelector);
+
         for (var i = 0; i < descriptions.length; i++) {
           $clamp(descriptions[i], {clamp: showLines});
         }

--- a/js/build.js
+++ b/js/build.js
@@ -16,6 +16,7 @@ $('[data-dynamic-lists-id]').each(function(){
     var awaitForDom = setInterval(function() {
       if ($(descriptionSelector).length) {
         clearInterval(awaitForDom);
+
         var descriptions = document.querySelectorAll(descriptionSelector);
 
         for (var i = 0; i < descriptions.length; i++) {

--- a/js/build.js
+++ b/js/build.js
@@ -7,4 +7,19 @@ $('[data-dynamic-lists-id]').each(function(){
   if (!data.layout) {
     dynamicLists[id] = new DynamicLists(data, container);
   }
+
+  if (data.layout === 'simple-list' || data.layout === 'news-feed') {
+    var showLines = Modernizr.ie11 ? 4 : 3;
+    var descriptionSelector = data.layout === 'simple-list' ? '.list-item-description' : '.news-feed-item-description';
+    var awaitForDom = setInterval(function() {
+      if ($(descriptionSelector).length) {
+        clearInterval(awaitForDom);
+        var descriptions = document.querySelectorAll(descriptionSelector);
+        for (var i = 0; i < descriptions.length; i++) {
+          $clamp(descriptions[i], {clamp: showLines});
+        }
+      }
+    }, 200);
+  }
+
 });

--- a/vendor/clamp.js
+++ b/vendor/clamp.js
@@ -1,0 +1,12 @@
+/*!
+* Clamp.js 0.5.1
+*
+* Copyright 2011-2013, Joseph Schmitt http://joe.sh
+* Released under the WTFPL license
+* http://sam.zoy.org/wtfpl/
+*/
+(function(){window.$clamp=function(c,d){function s(a,b){n.getComputedStyle||(n.getComputedStyle=function(a,b){this.el=a;this.getPropertyValue=function(b){var c=/(\-([a-z]){1})/g;"float"==b&&(b="styleFloat");c.test(b)&&(b=b.replace(c,function(a,b,c){return c.toUpperCase()}));return a.currentStyle&&a.currentStyle[b]?a.currentStyle[b]:null};return this});return n.getComputedStyle(a,null).getPropertyValue(b)}function t(a){a=a||c.clientHeight;var b=u(c);return Math.max(Math.floor(a/b),0)}function x(a){return u(c)*
+    a}function u(a){var b=s(a,"line-height");"normal"==b&&(b=1.2*parseInt(s(a,"font-size")));return parseInt(b)}function l(a){if(a.lastChild.children&&0<a.lastChild.children.length)return l(Array.prototype.slice.call(a.children).pop());if(a.lastChild&&a.lastChild.nodeValue&&""!=a.lastChild.nodeValue&&a.lastChild.nodeValue!=b.truncationChar)return a.lastChild;a.lastChild.parentNode.removeChild(a.lastChild);return l(c)}function p(a,d){if(d){var e=a.nodeValue.replace(b.truncationChar,"");f||(h=0<k.length?
+    k.shift():"",f=e.split(h));1<f.length?(q=f.pop(),r(a,f.join(h))):f=null;m&&(a.nodeValue=a.nodeValue.replace(b.truncationChar,""),c.innerHTML=a.nodeValue+" "+m.innerHTML+b.truncationChar);if(f){if(c.clientHeight<=d)if(0<=k.length&&""!=h)r(a,f.join(h)+h+q),f=null;else return c.innerHTML}else""==h&&(r(a,""),a=l(c),k=b.splitOnChars.slice(0),h=k[0],q=f=null);if(b.animate)setTimeout(function(){p(a,d)},!0===b.animate?10:b.animate);else return p(a,d)}}function r(a,c){a.nodeValue=c+b.truncationChar}d=d||{};
+    var n=window,b={clamp:d.clamp||2,useNativeClamp:"undefined"!=typeof d.useNativeClamp?d.useNativeClamp:!0,splitOnChars:d.splitOnChars||[".","-","\u2013","\u2014"," "],animate:d.animate||!1,truncationChar:d.truncationChar||"\u2026",truncationHTML:d.truncationHTML},e=c.style,y=c.innerHTML,z="undefined"!=typeof c.style.webkitLineClamp,g=b.clamp,v=g.indexOf&&(-1<g.indexOf("px")||-1<g.indexOf("em")),m;b.truncationHTML&&(m=document.createElement("span"),m.innerHTML=b.truncationHTML);var k=b.splitOnChars.slice(0),
+    h=k[0],f,q;"auto"==g?g=t():v&&(g=t(parseInt(g)));var w;z&&b.useNativeClamp?(e.overflow="hidden",e.textOverflow="ellipsis",e.webkitBoxOrient="vertical",e.display="-webkit-box",e.webkitLineClamp=g,v&&(e.height=b.clamp+"px")):(e=x(g),e<=c.clientHeight&&(w=p(l(c),e)));return{original:y,clamped:w}}})();

--- a/widget.json
+++ b/widget.json
@@ -73,6 +73,7 @@
       "vendor/mixitup-multifilter.min.js",
       "vendor/autosize.js",
       "vendor/unorm.js",
+      "vendor/clamp.js",
       "js/default-configs/layouts-config.js",
       "js/build-lists.js",
       "js/build.js",


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5030

## Description
Show clipped description in a simple list for IE11

## Screenshots/screencasts
MS IE11
![image](https://user-images.githubusercontent.com/53430352/69156014-72553300-0aeb-11ea-9cab-57f19aa80a19.png)

MS EDGE
![image](https://user-images.githubusercontent.com/53430352/69156389-fb6c6a00-0aeb-11ea-919c-559a5b0a6705.png)

Firefox
![image](https://user-images.githubusercontent.com/53430352/69156494-2c4c9f00-0aec-11ea-8243-fec1f0139f19.png)

Chrome
![image](https://user-images.githubusercontent.com/53430352/69156530-3a022480-0aec-11ea-8267-3f041ddac222.png)


## Backward compatibility

This change is fully backward compatible.

## Notes
Use set interval function to wait until the element will appear in the DOM.