### PR TITLE
Show normaly clipped news feed layout to a user

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -775,6 +775,11 @@
   line-height: 1.5;
 }
 
+.new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description,
+.new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-title {
+  max-height: 4.4em;	
+}
+
 .new-news-feed-list-container .slide-over .news-feed-item-inner-content .news-feed-item-description p {
   margin-bottom: 0;
 }

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -548,6 +548,12 @@
   background-repeat: no-repeat;
 }
 
+.simple-list-item .list-item-title,	
+.simple-list-item .list-item-description,	
+.simple-list-item .list-item-subtitle {	
+max-height: 4.4em;
+}
+
 .simple-list-item .list-item-title {
   font-size: 18px;
 }


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5373

## Description
Show normally clipped news feed layout to a user

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/69795624-339f3700-11d5-11ea-88a3-1d32bdd41d39.png)


## Backward compatibility

This change is fully backward compatible.

## Notes
It seems that `display: -webkit-box` doesn't work right there is more than one child in it. The only way I've found to fix this it was by adding the `max-height` attribute.
I didn't add it threw the javascript because I wasn't able to found this kind of solution in the library we are using.
I've added this solution as well to the simple list because when a user will try to do the same description in the simple list he will counter the same issue.