### PR TITLE
Returned CSS code to support fa-times-thin class for close icon

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -122,19 +122,19 @@
   to use UNICODE icons instead of SVG icons.
 */
 
-.close-icon .fa-times-thin {
+[data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 4px;
   font-size: 0.8em !important;
 }
 
-.close-icon .fa-times-thin::before {
+[data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin::before {
   content: '\002573';
 }
 
 /* IE11 layout */
 @media screen and (-ms-high-contrast: none) {
-  .close-icon .fa-times-thin {
+  [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
     padding-top: 0px;
     padding-bottom: 5px;
   }
@@ -143,7 +143,7 @@
 /* Safari layout */
 @media not all and (min-resolution:.001dpcm) { 
   @media {
-    .close-icon .fa-times-thin {
+    [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
       padding-top: 1px;
       padding-bottom: 0px;
     }
@@ -151,11 +151,11 @@
 }
 
 /* For native devices */
-.native.android .close-icon .fa-times-thin {
+.native.android [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
   padding-top: 5px;
 }
 
-.native.ios .close-icon .fa-times-thin {
+.native.ios [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
   padding-top: 1px;
 }
 
@@ -165,7 +165,7 @@
 
 /* For MS Edge */
 @supports (-ms-ime-align:auto) {
-  .close-icon .fa-times-thin {
+  [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
     padding-top: 1px;
     padding-bottom: 3px;
   }
@@ -173,19 +173,19 @@
 
 /* For Firefox */
 @-moz-document url-prefix() {
-  .close-icon .fa-times-thin {
+  [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 5px;
   }
 
-  .no-windows .close-icon .fa-times-thin {
+  .no-windows [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 2px;
   }
 }
 
 /* For Android Chrome browser*/
-.android.no-native .close-icon .fa-times-thin {
+.android.no-native [data-widget-package="com.fliplet.dynamic-lists"] .close-icon .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 2px;
 }

--- a/css/build.css
+++ b/css/build.css
@@ -116,3 +116,71 @@
 .close-icon {
   width: 40%;
 }
+
+.fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) { 
+  @media {
+    .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/build.css
+++ b/css/build.css
@@ -122,19 +122,19 @@
   to use UNICODE icons instead of SVG icons.
 */
 
-.fa-times-thin {
+.close-icon .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 4px;
   font-size: 0.8em !important;
 }
 
-.fa-times-thin::before {
+.close-icon .fa-times-thin::before {
   content: '\002573';
 }
 
 /* IE11 layout */
 @media screen and (-ms-high-contrast: none) {
-  .fa-times-thin {
+  .close-icon .fa-times-thin {
     padding-top: 0px;
     padding-bottom: 5px;
   }
@@ -143,7 +143,7 @@
 /* Safari layout */
 @media not all and (min-resolution:.001dpcm) { 
   @media {
-    .fa-times-thin {
+    .close-icon .fa-times-thin {
       padding-top: 1px;
       padding-bottom: 0px;
     }
@@ -151,11 +151,11 @@
 }
 
 /* For native devices */
-.native.android .fa-times-thin {
+.native.android .close-icon .fa-times-thin {
   padding-top: 5px;
 }
 
-.native.ios .fa-times-thin {
+.native.ios .close-icon .fa-times-thin {
   padding-top: 1px;
 }
 
@@ -165,7 +165,7 @@
 
 /* For MS Edge */
 @supports (-ms-ime-align:auto) {
-  .fa-times-thin {
+  .close-icon .fa-times-thin {
     padding-top: 1px;
     padding-bottom: 3px;
   }
@@ -173,19 +173,19 @@
 
 /* For Firefox */
 @-moz-document url-prefix() {
-  .fa-times-thin {
+  .close-icon .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 5px;
   }
 
-  .no-windows .fa-times-thin {
+  .no-windows .close-icon .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 2px;
   }
 }
 
 /* For Android Chrome browser*/
-.android.no-native .fa-times-thin {
+.android.no-native .close-icon .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 2px;
 }

--- a/css/build.css
+++ b/css/build.css
@@ -121,6 +121,7 @@
   This part of the code needed for support .fa-times-thin class in users who manage to update the LFD component
   before we changed the UNICODE icon for the SVG icon.
 */
+
 .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 4px;

--- a/css/build.css
+++ b/css/build.css
@@ -117,6 +117,10 @@
   width: 40%;
 }
 
+/*
+  This part of the code needed for support .fa-times-thin class in users who manage to update the LFD component
+  before we changed the UNICODE icon for the SVG icon.
+*/
 .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 4px;

--- a/css/build.css
+++ b/css/build.css
@@ -118,8 +118,8 @@
 }
 
 /*
-  This part of the code needed for support .fa-times-thin class in users who manage to update the LFD component
-  before we changed the UNICODE icon for the SVG icon.
+  This part of the code is needed for supporting .fa-times-thin class in users who updated
+  to use UNICODE icons instead of SVG icons.
 */
 
 .fa-times-thin {


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5347

## Description
Returned CSS code to support fa-times-thin class for the close icon according to this [comment](https://github.com/Fliplet/fliplet-studio/issues/5347#issuecomment-558279446).
## Backward compatibility

This change is fully backward compatible.

## Notes
I wasn't able to test it properly because of cant replicate the issue.