### PR TITLE
Highlight errors in the directory layout

### DIFF
--- a/js/interface-lists.js
+++ b/js/interface-lists.js
@@ -346,8 +346,7 @@ function attahObservers() {
           if (errors && errors.length) {
             $('.component-error').removeClass('hidden').addClass('bounceInUp');
             errors.forEach(function(field) {
-               $(field).addClass('has-error');
-               $(field).parents('.form-group').addClass('has-error');
+              toggleError(true, field);
             });
             if (!linkAddEntryProvider || !linkEditEntryProvider) {
               withError = true;
@@ -358,8 +357,7 @@ function attahObservers() {
             }, 4000);
             return;
           } else {
-            $('.has-error').removeClass('has-error');
-            $('.component-error').addClass('hidden');
+            toggleError(false);
           }
         }
 
@@ -394,8 +392,7 @@ function attahObservers() {
           if (errors && errors.length) {
             $('.component-error').removeClass('hidden').addClass('bounceInUp');
             errors.forEach(function(field) {
-               $(field).addClass('has-error');
-               $(field).parents('.form-group').addClass('has-error');
+              toggleError(true, field);
             });
             if (!linkAddEntryProvider || !linkEditEntryProvider) {
               withError = true;
@@ -406,8 +403,7 @@ function attahObservers() {
             }, 4000);
             return;
           } else {
-            $('.has-error').removeClass('has-error');
-            $('.component-error').addClass('hidden');
+            toggleError(false);
           }
         }
 
@@ -437,8 +433,7 @@ function attahObservers() {
           if (errors.length) {
             $('.component-error').removeClass('hidden').addClass('bounceInUp');
             errors.forEach(function(field) {
-               $(field).addClass('has-error');
-               $(field).parents('.form-group').addClass('has-error');
+              toggleError(true, field);
             });
             if (!linkAddEntryProvider || !linkEditEntryProvider) {
               withError = true;
@@ -449,8 +444,7 @@ function attahObservers() {
             }, 4000);
             return;
           } else {
-            $('.has-error').removeClass('has-error');
-            $('.component-error').addClass('hidden');
+            toggleError(false)
           }
         }
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5439

## Description
Highlight errors in the directory layout

## Screenshots/screencasts
![lfd-errors](https://user-images.githubusercontent.com/53430352/71359013-9f39b180-2593-11ea-9de1-32f3d1c60c95.gif)


## Backward compatibility

This change is fully backward compatible.