### PR TITLE
Fixed error highlight when deleting entry set to the users and admins

### DIFF
--- a/js/interface-lists.js
+++ b/js/interface-lists.js
@@ -362,7 +362,7 @@ function attahObservers() {
         }
 
         if ((widgetData.editEntry && widgetData.editPermissions === 'users-admins')
-          || (widgetData.deleteEntry && widgetData.deletePermissions === 'everyone')) {
+          || (widgetData.deleteEntry && widgetData.deletePermissions === 'users-admins')) {
           var errors = [];
           var values = [
             {


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5439#issuecomment-572021605

## Description
Fixed error highlight when deleting entry set to the users and admins

## Screenshots/screencasts
![highlight](https://user-images.githubusercontent.com/53430352/71984616-dbc30980-3231-11ea-8b67-4f7dbc00a17b.gif)

## Backward compatibility

This change is fully backward compatible.