### PR TITLE
Now images with similar titles display correctly

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -792,7 +792,10 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
             return;
           }
 
-          if (entryData[column] && file.name.indexOf(entryData[column]) !== -1) {
+          var lastDotInNameIndex = file.name.lastIndexOf('.');
+          var nameWithoutExt = file.name.substring(0, lastDotInNameIndex);
+
+          if (entryData[column] && (file.name === entryData[column] || nameWithoutExt === entryData[column])) {
             // File found
             entryData[column] = file.url;
             return true;

--- a/js/utils.js
+++ b/js/utils.js
@@ -792,10 +792,10 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
             return;
           }
 
-          var lastDotInNameIndex = file.name.lastIndexOf('.');
-          var nameWithoutExt = file.name.substring(0, lastDotInNameIndex);
+          // remove file extension 
+          var fileName = file.name.match(/(.+?)(?:\.[^\.]*$|$)/)[1];
 
-          if (entryData[column] && (file.name === entryData[column] || nameWithoutExt === entryData[column])) {
+          if (entryData[column] && (file.name === entryData[column] || fileName === entryData[column])) {
             // File found
             entryData[column] = file.url;
             return true;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5447

## Description
Before the issue occurred because of indexOf check. 
Now we will find the last dot in the image name, remove ext  and then compare names.

## Screenshots/screencasts
![photos-lfd](https://user-images.githubusercontent.com/52824207/72245791-062e1180-35fa-11ea-86c0-ee171e0c26aa.gif)

## Backward compatibility
This change is fully backward compatible.