### PR TITLE
Adds method for customising primary key and entry identifiers for social features

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -849,16 +849,29 @@
   padding-bottom: calc(65px + env(safe-area-inset-bottom));
 }
 
-[data-has-notch] .new-agenda-list-container.has-add-entry .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder {
-  padding-bottom: calc(65px + 34px);
+.new-agenda-list-container.has-add-entry .search-results {
+  padding-bottom: 65px;
 }
 
 .new-agenda-list-container .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
-.new-agenda-list-container.has-add-entry .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder {
+.new-agenda-list-container.has-add-entry .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
+.fl-with-bottom-menu.fl-menu-circle-left .new-agenda-list-container .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
+.fl-with-bottom-menu.fl-menu-circle-left .new-agenda-list-container.has-add-entry .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
+.fl-with-bottom-menu.fl-menu-circle-right .new-agenda-list-container .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
+.fl-with-bottom-menu.fl-menu-circle-right .new-agenda-list-container.has-add-entry .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder {
   /* My Agenda (Legacy) */
   /* Add Entry + My Agenda (Legacy) */
   padding-bottom: 80px;
   padding-bottom: calc(80px + env(safe-area-inset-bottom));
+}
+
+.new-agenda-list-container .agenda-list-controls ~ .search-results-wrapper .search-results,
+.new-agenda-list-container.has-add-entry .agenda-list-controls ~ .search-results-wrapper .search-results,
+.fl-with-bottom-menu.fl-menu-circle-left .new-agenda-list-container .agenda-list-controls ~ .search-results-wrapper .search-results,
+.fl-with-bottom-menu.fl-menu-circle-left .new-agenda-list-container.has-add-entry .agenda-list-controls ~ .search-results-wrapper .search-results,
+.fl-with-bottom-menu.fl-menu-circle-right .new-agenda-list-container .agenda-list-controls ~ .search-results-wrapper .search-results,
+.fl-with-bottom-menu.fl-menu-circle-right .new-agenda-list-container.has-add-entry .agenda-list-controls ~ .search-results-wrapper .search-results {
+  padding-bottom: 80px;
 }
 
 [data-has-notch] .new-agenda-list-container .agenda-list-controls ~ .agenda-cards-wrapper .agenda-list-day-holder .agenda-list-card-holder,
@@ -1077,6 +1090,10 @@
   font-size: 18px;
 }
 
+.agenda-detail-overlay .agenda-item-inner-content h2.agenda-item-title {
+  font-size: 27px;
+}
+
 .new-agenda-list-container .agenda-list-item.open .slide-over .agenda-item-inner-content h2.agenda-item-title:after,
 .agenda-detail-overlay .agenda-item-inner-content h2.agenda-item-title:after {
   content: '';
@@ -1197,6 +1214,7 @@
   bottom: 0;
   right: 0;
   overflow: auto;
+  padding-bottom: 15px;
 }
 
 .new-agenda-list-container .search-results {

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1472,22 +1472,27 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  return _this.getBookmarkQuery().then(function (query) {
-    return _this.Utils.Query.fetchAndCache({
-      key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
-      waitFor: 400,
-      request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
-        return instance.query({
-          where: {
-            content: query
-          },
-          exact: false
-        });
-      })
-    });
+  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+    return Promise.resolve();
+  }
+
+  return _this.Utils.Query.fetchAndCache({
+    key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
+    waitFor: 400,
+    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+      return instance.query({
+        where: {
+          content: {
+            entryId: { $regex: '\\d-bookmark' }
+          }
+        },
+        exact: false
+      });
+    })
   }).then(function (results) {
     var bookmarkedIds = _.compact(_.map(results.data, function (record) {
       var match = _.get(record, 'data.content.entryId', '').match(/(\d*)-bookmark/);
+
       return match ? parseInt(match[1], 10) : '';
     }));
 
@@ -1704,15 +1709,32 @@ DynamicList.prototype.toggleBookmarkStatus = function (record) {
 };
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
-  return Promise.resolve({
+  var defaultIdentifier = {
     entryId: record.id + '-bookmark',
     pageId: Fliplet.Env.get('pageId')
-  });
-};
+  };
+  var customIdentifier = Promise.resolve();
 
-DynamicList.prototype.getBookmarkQuery = function () {
-  return Promise.resolve({
-    entryId: { $regex: '\\d-bookmark' }
+  if (typeof this.data.getBookmarkIdentifier === 'function') {
+    customIdentifier = this.data.getBookmarkIdentifier({
+      record: record,
+      config: this.data,
+      id: this.data.id,
+      uuid: this.data.uuid,
+      container: this.$container
+    });
+
+    if (!(customIdentifier instanceof Promise)) {
+      customIdentifier = Promise.resolve(customIdentifier);
+    }
+  }
+
+  return customIdentifier.then(function (identifier) {
+    if (!identifier) {
+      identifier = defaultIdentifier;
+    }
+
+    return identifier;
   });
 };
 

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -110,6 +110,16 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
   }
 };
 
+DynamicList.prototype.clearFilters = function () {
+  this.toggleFilterElement(this.$container.find('.hidden-filter-controls-filter.mixitup-control-active'), false);
+  return this.searchData();
+};
+
+DynamicList.prototype.hideFilterOverlay = function () {
+  this.$container.find('.new-agenda-search-filter-overlay').removeClass('display');
+  $('body').removeClass('lock has-filter-overlay');
+};
+
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
 
@@ -216,17 +226,14 @@ DynamicList.prototype.attachObservers = function() {
       _this.$container.find('.clear-filters').removeClass('hidden');
     })
     .on('click', '.list-search-cancel', function() {
-      var $el = $(this);
+      // Hide filters
+      $(this).removeClass('active');
+      _this.$container.find('.hidden-filter-controls').removeClass('active');
+      _this.$container.find('.list-search-icon .fa-sliders').removeClass('active');
+      _this.calculateFiltersHeight(true);
 
-      _this.Utils.Page.updateFilterControlsContext();
-
-      if (_this.$container.find('.hidden-filter-controls').hasClass('active')) {
-        _this.$container.find('.hidden-filter-controls').removeClass('active');
-        $el.removeClass('active');
-        _this.$container.find('.list-search-icon .fa-sliders').removeClass('active');
-        _this.toggleListView();
-        _this.calculateFiltersHeight(true);
-      }
+      // Clear filters
+      _this.clearFilters();
     })
     .on('keydown change paste', '.search-holder input', function(e) {
       var $inputField = $(this);

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1472,7 +1472,7 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+  if (typeof _this.data.getBookmarkIdentifier === 'function' || _this.data.dataPrimaryKey) {
     return Promise.resolve();
   }
 
@@ -1711,7 +1711,7 @@ DynamicList.prototype.toggleBookmarkStatus = function (record) {
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-bookmark',

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1709,8 +1709,12 @@ DynamicList.prototype.toggleBookmarkStatus = function (record) {
 };
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-bookmark',
+    entryId: uniqueId + '-bookmark',
     pageId: Fliplet.Env.get('pageId')
   };
   var customIdentifier = Promise.resolve();

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1715,8 +1715,12 @@ DynamicList.prototype.searchData = function(options) {
 }
 
 DynamicList.prototype.getLikeIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-like',
+    entryId: uniqueId + '-like',
     pageId: Fliplet.Env.get('pageId')
   };
   var customIdentifier = Promise.resolve();
@@ -1836,8 +1840,12 @@ DynamicList.prototype.setupLikeButton = function(options) {
 }
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-bookmark'
+    entryId: uniqueId + '-bookmark'
   };
   var customIdentifier = Promise.resolve();
 
@@ -2033,8 +2041,12 @@ DynamicList.prototype.closeDetails = function() {
 /******************/
 
 DynamicList.prototype.getCommentIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    contentDataSourceEntryId: _.get(entry, 'id'),
+    contentDataSourceEntryId: uniqueId,
     type: 'comment'
   };
   var customIdentifier = Promise.resolve();

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -885,7 +885,7 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+  if (typeof _this.data.getBookmarkIdentifier === 'function' || _this.data.dataPrimaryKey) {
     return Promise.resolve();
   }
 
@@ -1717,7 +1717,7 @@ DynamicList.prototype.searchData = function(options) {
 DynamicList.prototype.getLikeIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-like',
@@ -1842,7 +1842,7 @@ DynamicList.prototype.setupLikeButton = function(options) {
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-bookmark'
@@ -2043,7 +2043,7 @@ DynamicList.prototype.closeDetails = function() {
 DynamicList.prototype.getCommentIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     contentDataSourceEntryId: uniqueId,

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -104,6 +104,16 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
   }
 }
 
+DynamicList.prototype.clearFilters = function () {
+  this.toggleFilterElement(this.$container.find('.hidden-filter-controls-filter.mixitup-control-active'), false);
+  return this.searchData();
+};
+
+DynamicList.prototype.hideFilterOverlay = function () {
+  this.$container.find('.news-feed-search-filter-overlay').removeClass('display');
+  $('body').removeClass('lock');
+};
+
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
 
@@ -335,17 +345,14 @@ DynamicList.prototype.attachObservers = function() {
       _this.$container.find('.clear-filters').removeClass('hidden');
     })
     .on('click', '.list-search-cancel', function() {
-      var $elementClicked = $(this);
-      var $parentElement = $elementClicked.parents('.new-news-feed-list-container');
+      // Hide filters
+      $(this).removeClass('active');
+      _this.$container.find('.hidden-filter-controls').removeClass('active');
+      _this.$container.find('.list-search-icon .fa-sliders').removeClass('active');
+      _this.$container.find('.hidden-filter-controls').animate({ height: 0 }, 200);
 
-      _this.Utils.Page.updateFilterControlsContext();
-
-      if ($parentElement.find('.hidden-filter-controls').hasClass('active')) {
-        $parentElement.find('.hidden-filter-controls').removeClass('active');
-        $elementClicked.removeClass('active');
-        $parentElement.find('.list-search-icon .fa-sliders').removeClass('active');
-        $parentElement.find('.hidden-filter-controls').animate({ height: 0 }, 200);
-      }
+      // Clear filters
+      _this.clearFilters();
     })
     .on('keydown change paste', '.search-holder input', function(e) {
       var $inputField = $(this);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1440,7 +1440,7 @@ DynamicList.prototype.searchData = function(options) {
 DynamicList.prototype.getLikeIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-like'
@@ -1563,7 +1563,7 @@ DynamicList.prototype.setupLikeButton = function(options) {
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-bookmark'
@@ -1727,7 +1727,7 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+  if (typeof _this.data.getBookmarkIdentifier === 'function' || _this.data.dataPrimaryKey) {
     return Promise.resolve();
   }
 
@@ -1994,7 +1994,7 @@ DynamicList.prototype.closeDetails = function() {
 DynamicList.prototype.getCommentIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     contentDataSourceEntryId: uniqueId,

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -96,6 +96,16 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
   }
 }
 
+DynamicList.prototype.clearFilters = function () {
+  this.toggleFilterElement(this.$container.find('.hidden-filter-controls-filter.mixitup-control-active'), false);
+  return this.searchData();
+};
+
+DynamicList.prototype.hideFilterOverlay = function () {
+  this.$container.find('.simple-list-search-filter-overlay').removeClass('display');
+  $('body').removeClass('lock');
+};
+
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
 
@@ -309,17 +319,14 @@ DynamicList.prototype.attachObservers = function() {
       _this.$container.find('.clear-filters').removeClass('hidden');
     })
     .on('click', '.list-search-cancel', function() {
-      var $elementClicked = $(this);
-      var $parentElement = $elementClicked.parents('.simple-list-container');
+      // Hide filters
+      $(this).removeClass('active');
+      _this.$container.find('.hidden-filter-controls').removeClass('active');
+      _this.$container.find('.list-search-icon .fa-sliders').removeClass('active');
+      _this.$container.find('.hidden-filter-controls').animate({ height: 0 }, 200);
 
-      _this.Utils.Page.updateFilterControlsContext();
-
-      if ($parentElement.find('.hidden-filter-controls').hasClass('active')) {
-        $parentElement.find('.hidden-filter-controls').removeClass('active');
-        $elementClicked.removeClass('active');
-        $parentElement.find('.list-search-icon .fa-sliders').removeClass('active');
-        $parentElement.find('.hidden-filter-controls').animate({ height: 0 }, 200);
-      }
+      // Clear filters
+      _this.clearFilters();
     })
     .on('keydown change paste', '.search-holder input', function(e) {
       var $inputField = $(this);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1438,8 +1438,31 @@ DynamicList.prototype.searchData = function(options) {
 }
 
 DynamicList.prototype.getLikeIdentifier = function (record) {
-  return Promise.resolve({
+  var defaultIdentifier = {
     entryId: record.id + '-like'
+  };
+  var customIdentifier = Promise.resolve();
+
+  if (typeof this.data.getLikeIdentifier === 'function') {
+    customIdentifier = this.data.getLikeIdentifier({
+      record: record,
+      config: this.data,
+      id: this.data.id,
+      uuid: this.data.uuid,
+      container: this.$container
+    });
+
+    if (!(customIdentifier instanceof Promise)) {
+      customIdentifier = Promise.resolve(customIdentifier);
+    }
+  }
+
+  return customIdentifier.then(function (identifier) {
+    if (!identifier) {
+      identifier = defaultIdentifier;
+    }
+
+    return identifier;
   });
 };
 
@@ -1534,14 +1557,31 @@ DynamicList.prototype.setupLikeButton = function(options) {
 }
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
-  return Promise.resolve({
+  var defaultIdentifier = {
     entryId: record.id + '-bookmark'
-  });
-};
+  };
+  var customIdentifier = Promise.resolve();
 
-DynamicList.prototype.getBookmarkQuery = function () {
-  return Promise.resolve({
-    entryId: { $regex: '\\d-bookmark' }
+  if (typeof this.data.getBookmarkIdentifier === 'function') {
+    customIdentifier = this.data.getBookmarkIdentifier({
+      record: record,
+      config: this.data,
+      id: this.data.id,
+      uuid: this.data.uuid,
+      container: this.$container
+    });
+
+    if (!(customIdentifier instanceof Promise)) {
+      customIdentifier = Promise.resolve(customIdentifier);
+    }
+  }
+
+  return customIdentifier.then(function (identifier) {
+    if (!identifier) {
+      identifier = defaultIdentifier;
+    }
+
+    return identifier;
   });
 };
 
@@ -1679,19 +1719,23 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  return _this.getBookmarkQuery().then(function (query) {
-    return _this.Utils.Query.fetchAndCache({
-      key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
-      waitFor: 400,
-      request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
-        return instance.query({
-          where: {
-            content: query
-          },
-          exact: false
-        });
-      })
-    });
+  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+    return Promise.resolve();
+  }
+
+  return _this.Utils.Query.fetchAndCache({
+    key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
+    waitFor: 400,
+    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+      return instance.query({
+        where: {
+          content: {
+            entryId: { $regex: '\\d-bookmark' }
+          }
+        },
+        exact: false
+      });
+    })
   }).then(function (results) {
     var bookmarkedIds = _.compact(_.map(results.data, function (record) {
       var match = _.get(record, 'data.content.entryId', '').match(/(\d*)-bookmark/);
@@ -1939,10 +1983,33 @@ DynamicList.prototype.closeDetails = function() {
 /**** COMMENTS ****/
 /******************/
 
-DynamicList.prototype.getCommentIdentifier = function (entry) {
-  return Promise.resolve({
+DynamicList.prototype.getCommentIdentifier = function (record) {
+  var defaultIdentifier = {
     contentDataSourceEntryId: _.get(entry, 'id'),
     type: 'comment'
+  };
+  var customIdentifier = Promise.resolve();
+
+  if (typeof this.data.getCommentIdentifier === 'function') {
+    customIdentifier = this.data.getCommentIdentifier({
+      record: record,
+      config: this.data,
+      id: this.data.id,
+      uuid: this.data.uuid,
+      container: this.$container
+    });
+
+    if (!(customIdentifier instanceof Promise)) {
+      customIdentifier = Promise.resolve(customIdentifier);
+    }
+  }
+
+  return customIdentifier.then(function (identifier) {
+    if (!identifier) {
+      identifier = defaultIdentifier;
+    }
+
+    return identifier;
   });
 };
 

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1438,8 +1438,12 @@ DynamicList.prototype.searchData = function(options) {
 }
 
 DynamicList.prototype.getLikeIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-like'
+    entryId: uniqueId + '-like'
   };
   var customIdentifier = Promise.resolve();
 
@@ -1557,8 +1561,12 @@ DynamicList.prototype.setupLikeButton = function(options) {
 }
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-bookmark'
+    entryId: uniqueId + '-bookmark'
   };
   var customIdentifier = Promise.resolve();
 
@@ -1984,8 +1992,12 @@ DynamicList.prototype.closeDetails = function() {
 /******************/
 
 DynamicList.prototype.getCommentIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    contentDataSourceEntryId: _.get(entry, 'id'),
+    contentDataSourceEntryId: uniqueId,
     type: 'comment'
   };
   var customIdentifier = Promise.resolve();

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1401,8 +1401,12 @@ DynamicList.prototype.searchData = function(options) {
 }
 
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
+  var uniqueId = this.Utils.Record.getUniqueId({
+    record: record,
+    field: this.data.dataPrimaryKey
+  });
   var defaultIdentifier = {
-    entryId: record.id + '-bookmark'
+    entryId: uniqueId + '-bookmark'
   };
   var customIdentifier = Promise.resolve();
 

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1403,7 +1403,7 @@ DynamicList.prototype.searchData = function(options) {
 DynamicList.prototype.getBookmarkIdentifier = function (record) {
   var uniqueId = this.Utils.Record.getUniqueId({
     record: record,
-    field: this.data.dataPrimaryKey
+    config: this.data
   });
   var defaultIdentifier = {
     entryId: uniqueId + '-bookmark'
@@ -1539,7 +1539,7 @@ DynamicList.prototype.getAllBookmarks = function () {
     return Promise.resolve();
   }
 
-  if (typeof _this.data.getBookmarkIdentifier === 'function') {
+  if (typeof _this.data.getBookmarkIdentifier === 'function' || _this.data.dataPrimaryKey) {
     return Promise.resolve();
   }
 

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -101,6 +101,16 @@ DynamicList.prototype.toggleFilterElement = function (target, toggle) {
   }
 }
 
+DynamicList.prototype.clearFilters = function () {
+  this.toggleFilterElement(this.$container.find('.hidden-filter-controls-filter.mixitup-control-active'), false);
+  return this.searchData();
+};
+
+DynamicList.prototype.hideFilterOverlay = function () {
+  this.$container.find('.small-card-search-filter-overlay').removeClass('display');
+  $('body').removeClass('lock');
+};
+
 DynamicList.prototype.attachObservers = function() {
   var _this = this;
 
@@ -383,17 +393,14 @@ DynamicList.prototype.attachObservers = function() {
       _this.$container.find('.clear-filters').removeClass('hidden');
     })
     .on('click', '.list-search-cancel', function() {
-      var $elementClicked = $(this);
-      var $parentElement = $elementClicked.parents('.new-small-card-list-container');
+      // Hide filters
+      $(this).removeClass('active');
+      _this.$container.find('.hidden-filter-controls').removeClass('active');
+      _this.$container.find('.list-search-icon .fa-sliders').removeClass('active');
+      _this.$container.find('.hidden-filter-controls').animate({ height: 0 }, 200);
 
-      _this.Utils.Page.updateFilterControlsContext();
-
-      if ($parentElement.find('.hidden-filter-controls').hasClass('active')) {
-        $parentElement.find('.hidden-filter-controls').removeClass('active');
-        $elementClicked.removeClass('active');
-        $parentElement.find('.list-search-icon .fa-sliders').removeClass('active');
-        $parentElement.find('.hidden-filter-controls').animate({ height: 0 }, 200);
-      }
+      // Clear filters
+      _this.clearFilters();
     })
     .on('keydown change paste', '.search-holder input', function(e) {
       var $inputField = $(this);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1114,6 +1114,16 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     }
   }
 
+  function getRecordUniqueId(options) {
+    options = options || {};
+
+    if (typeof options.field === 'string' && options.field.length) {
+      return _.get(options, ['record', 'data', options.field]);
+    }
+
+    return _.get(options, ['record', 'id']);
+  }
+
   function userIsAdmin(config, userData) {
     var adminValue = _.get(userData, config.userAdminColumn);
 
@@ -1342,7 +1352,8 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       addFilterProperties: addRecordFilterProperties,
       updateFiles: updateRecordFiles,
       prepareData: prepareRecordsData,
-      addComputedFields: addRecordsComputedFields
+      addComputedFields: addRecordsComputedFields,
+      getUniqueId: getRecordUniqueId
     },
     User: {
       isAdmin: userIsAdmin,

--- a/js/utils.js
+++ b/js/utils.js
@@ -670,6 +670,25 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     });
   }
 
+  function getRecordUniqueId(options) {
+    options = options || {};
+
+    var primaryKey = _.get(options, 'config.dataPrimaryKey');
+
+    if (typeof primaryKey === 'function') {
+      return primaryKey({
+        record: options.record,
+        config: options.config
+      });
+    }
+
+    if (typeof primaryKey === 'string' && primaryKey.length) {
+      return _.get(options, ['record', 'data', primaryKey]);
+    }
+
+    return _.get(options, ['record', 'id']);
+  }
+
   function getRecordFieldValues(records, fields) {
     // Extract a list of filter values based on a list of records and filter fields
     if (_.isUndefined(fields) || _.isNull(fields)) {
@@ -1114,25 +1133,6 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     }
   }
 
-  function getRecordUniqueId(options) {
-    options = options || {};
-
-    var primaryKey = _.get(options, 'config.dataPrimaryKey');
-
-    if (typeof primaryKey === 'function') {
-      return primaryKey({
-        record: options.record,
-        config: options.config
-      });
-    }
-
-    if (typeof primaryKey === 'string' && primaryKey.length) {
-      return _.get(options, ['record', 'data', primaryKey]);
-    }
-
-    return _.get(options, ['record', 'id']);
-  }
-
   function userIsAdmin(config, userData) {
     var adminValue = _.get(userData, config.userAdminColumn);
 
@@ -1349,7 +1349,8 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       isEditable: recordIsEditable,
       isDeletable: recordIsDeletable,
       isCurrentUser: recordIsCurrentUser,
-      matchesFilters: recordMatchesFilters
+      matchesFilters: recordMatchesFilters,
+      getUniqueId: getRecordUniqueId
     },
     Records: {
       runFilters: runRecordFilters,
@@ -1361,8 +1362,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       addFilterProperties: addRecordFilterProperties,
       updateFiles: updateRecordFiles,
       prepareData: prepareRecordsData,
-      addComputedFields: addRecordsComputedFields,
-      getUniqueId: getRecordUniqueId
+      addComputedFields: addRecordsComputedFields
     },
     User: {
       isAdmin: userIsAdmin,

--- a/js/utils.js
+++ b/js/utils.js
@@ -1117,8 +1117,17 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
   function getRecordUniqueId(options) {
     options = options || {};
 
-    if (typeof options.field === 'string' && options.field.length) {
-      return _.get(options, ['record', 'data', options.field]);
+    var primaryKey = _.get(options, 'config.dataPrimaryKey');
+
+    if (typeof primaryKey === 'function') {
+      return primaryKey({
+        record: options.record,
+        config: options.config
+      });
+    }
+
+    if (typeof primaryKey === 'string' && primaryKey.length) {
+      return _.get(options, ['record', 'data', primaryKey]);
     }
 
     return _.get(options, ['record', 'id']);


### PR DESCRIPTION
Also follows https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/299 to adjust some agenda layout spacing.

To define a custom primary key:

```js
Fliplet.Hooks.on('flListDataBeforeGetData', function (options) {
  options.config.dataPrimaryKey = 'Session ID';
});
```

To create a custom primary key based on various data:

```js
Fliplet.Hooks.on('flListDataBeforeGetData', function (options) {
  options.config.dataPrimaryKey = function (data) {
    return _.get(data, 'record.data.Title') + '-' + _.get(data, 'record.data.Date');
  };
});
```