### PR TITLE
User will not lose components when change they position in the new D&D

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1,8 +1,7 @@
 var dynamicLists = dynamicLists || {};
-$('[data-dynamic-lists-id]').each(function(){
+Fliplet.Widget.instance('dynamic-lists', function(data){
   var container = this;
-  var id = $(this).data('dynamic-lists-id');
-  var data = Fliplet.Widget.getData(id);
+  var id = data.id;
 
   if (!data.layout) {
     dynamicLists[id] = new DynamicLists(data, container);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5354

## Description
Changed components so they work with Fliplet.Widget.instance now.

## Screenshots/screencasts
https://share.getcloudapp.com/Qwu7RnDj

## Backward compatibility

This change is fully backward compatible.