### PR TITLE
Support for segmentation user bookmarks

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2541,8 +2541,14 @@ var DynamicLists = (function() {
                 filter: {
                   user: {
                     $or: [
+                      // Guest users
                       { uuid: 'session.uuid' },
-                      { email: 'session.email' }
+
+                      // Logged in users
+                      { email: 'session.email' },
+
+                      // Legacy support just in case
+                      { dataSourceEntryId: 'session.id' }
                     ]
                   }
                 }
@@ -2551,6 +2557,13 @@ var DynamicLists = (function() {
           }
         }).then(function (dataSource) {
           _this.config.bookmarkDataSourceId = dataSource.id;
+          _this.config.dataSourceViews = _this.config.dataSourceViews || [];
+
+          _this.config.dataSourceViews.push({
+            id: dataSource.id,
+            name: 'userBookmarks',
+            bundle: true
+          })
         });
       } else if (!_this.config.social.bookmark && _this.config.bookmarkDataSourceId) {
         _this.config.bookmarkDataSourceId = '';

--- a/js/interface.js
+++ b/js/interface.js
@@ -2528,11 +2528,27 @@ var DynamicLists = (function() {
         _this.config.likesDataSourceId = '';
       }
       if (_this.config.social.bookmark && (!_this.config.bookmarkDataSourceId || _this.config.bookmarkDataSourceId === '')) {
-        // Create likes data source
+        // Create bookmarks data source
         bookmarksPromise = Fliplet.DataSources.create({
           name: appName + ' - Bookmarks',
-          bundle: true,
-          organizationId: organizationId // optional
+          bundle: false,
+          organizationId: organizationId, // optional
+          definition: {
+            views: [
+              {
+                name: 'userBookmarks',
+                bundle: true,
+                filter: {
+                  user: {
+                    $or: [
+                      { uuid: 'session.uuid' },
+                      { email: 'session.email' }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
         }).then(function (dataSource) {
           _this.config.bookmarkDataSourceId = dataSource.id;
         });

--- a/js/interface.js
+++ b/js/interface.js
@@ -2563,7 +2563,10 @@ var DynamicLists = (function() {
             id: dataSource.id,
             name: 'userBookmarks',
             bundle: true
-          })
+          });
+
+          // Ensure we don't store the same view twice
+          _this.config.dataSourceViews = _.uniqWith(_this.config.dataSourceViews, _.isEqual);
         });
       } else if (!_this.config.social.bookmark && _this.config.bookmarkDataSourceId) {
         _this.config.bookmarkDataSourceId = '';

--- a/js/interface.js
+++ b/js/interface.js
@@ -2561,7 +2561,7 @@ var DynamicLists = (function() {
 
           _this.config.dataSourceViews.push({
             id: dataSource.id,
-            name: 'userBookmarks',
+            view: 'userBookmarks',
             bundle: true
           });
 

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1544,7 +1544,10 @@ DynamicList.prototype.getAllBookmarks = function () {
   return _this.Utils.Query.fetchAndCache({
     key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
     waitFor: 400,
-    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+    request: Fliplet.Profile.Content({
+      dataSourceId: _this.data.bookmarkDataSourceId,
+      view: 'userBookmarks'
+    }).then(function (instance) {
       return instance.query({
         where: {
           content: {
@@ -1832,6 +1835,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
         var btn = LikeButton({
           target: target,
           dataSourceId: _this.data.bookmarkDataSourceId,
+          view: 'userBookmarks',
           content: identifier,
           allowAnonymous: true,
           name: Fliplet.Env.get('pageTitle') + '/' + title,

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -894,7 +894,10 @@ DynamicList.prototype.getAllBookmarks = function () {
   return _this.Utils.Query.fetchAndCache({
     key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
     waitFor: 400,
-    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+    request: Fliplet.Profile.Content({
+      dataSourceId: _this.data.bookmarkDataSourceId,
+      view: 'userBookmarks'
+    }).then(function (instance) {
       return instance.query({
         where: {
           content: {
@@ -1918,6 +1921,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
         var btn = LikeButton({
           target: target,
           dataSourceId: _this.data.bookmarkDataSourceId,
+          view: 'userBookmarks',
           content: identifier,
           name: Fliplet.Env.get('pageTitle') + '/' + title,
           likeLabel: '<i class="fa fa-bookmark-o fa-lg"></i>',

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1637,6 +1637,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
         var btn = LikeButton({
           target: '.simple-list-bookmark-holder-' + id,
           dataSourceId: _this.data.bookmarkDataSourceId,
+          view: 'userBookmarks',
           content: identifier,
           name: Fliplet.Env.get('pageTitle') + '/' + title,
           likeLabel: '<i class="fa fa-bookmark-o fa-lg"></i>',

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1756,7 +1756,10 @@ DynamicList.prototype.getAllBookmarks = function () {
   return _this.Utils.Query.fetchAndCache({
     key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
     waitFor: 400,
-    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+    request: Fliplet.Profile.Content({
+      dataSourceId: _this.data.bookmarkDataSourceId,
+      view: 'userBookmarks'
+    }).then(function (instance) {
       return instance.query({
         where: {
           content: {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1482,6 +1482,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
         var btn = LikeButton({
           target: target,
           dataSourceId: _this.data.bookmarkDataSourceId,
+          view: 'userBookmarks',
           content: identifier,
           name: Fliplet.Env.get('pageTitle') + '/' + title,
           likeLabel: '<i class="fa fa-bookmark-o"></i>',
@@ -1572,7 +1573,10 @@ DynamicList.prototype.getAllBookmarks = function () {
   return _this.Utils.Query.fetchAndCache({
     key: 'bookmarks-' + _this.data.bookmarkDataSourceId,
     waitFor: 400,
-    request: Fliplet.Profile.Content(_this.data.bookmarkDataSourceId).then(function (instance) {
+    request: Fliplet.Profile.Content({
+      dataSourceId: _this.data.bookmarkDataSourceId,
+      view: 'userBookmarks'
+    }).then(function (instance) {
       return instance.query({
         where: {
           content: {

--- a/vendor/codemirror/addon/format/formatting.js
+++ b/vendor/codemirror/addon/format/formatting.js
@@ -18,7 +18,6 @@
   CodeMirror.extendMode("javascript", {
     commentStart: "/*",
     commentEnd: "*/",
-    // FIXME semicolons inside of for
     newlineAfterToken: function(_type, content, textAfter, state) {
       if (this.jsonMode) {
         return /^[\[,{]$/.test(content) || /^}/.test(textAfter);

--- a/widget.json
+++ b/widget.json
@@ -107,6 +107,7 @@
     "summary-fields.$.appFolderId:app",
     "detailViewOptions.$.appFolderId:app",
     "summary-fields.$.organizationFolderId:organization",
-    "detailViewOptions.$.organizationFolderId:organization"
+    "detailViewOptions.$.organizationFolderId:organization",
+    "dataSourceViews.$.id:dataSourceView"
   ]
 }


### PR DESCRIPTION
This PR adds support for
- creating a user's bookmarks view definition when creating the bookmarks data source (bundled by default)
- all internal features to use the above newly defined view
- adds new reference type for views

Existing usage will be unaffected as the bookmarks data sources won't have the view definition, resulting in simply skipping these inputs from having any effect.

---

requires https://github.com/Fliplet/fliplet-api/pull/3866