### PR TITLE
Improves hooks for before and after list render

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -19,6 +19,7 @@ function DynamicList(id, data, container) {
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
   this.data.computedFields = this.data.computedFields || {};
+  this.data.forceRenderList = false;
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
   this.$overlay;
 
@@ -1118,7 +1119,7 @@ DynamicList.prototype.parseSearchQueries = function() {
   if (!_.get(_this.pvSearchQuery, 'value')) {
     // Continue to exectute query filters
     return _this.searchData({
-      query: true
+      initialRender: true
     });
   }
 
@@ -1128,7 +1129,7 @@ DynamicList.prototype.parseSearchQueries = function() {
       value: _this.pvSearchQuery.value,
       column: _this.pvSearchQuery.column,
       openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-      query: true
+      initialRender: true
     });
   }
 
@@ -1139,7 +1140,7 @@ DynamicList.prototype.parseSearchQueries = function() {
   return _this.searchData({
     value: _this.pvSearchQuery.value,
     openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-    query: true
+    initialRender: true
   });
 }
 
@@ -1678,7 +1679,7 @@ DynamicList.prototype.searchData = function(options) {
       _this.$container.find('.hidden-search-controls').addClass('active');
       _this.$container.find('.hidden-search-controls')[searchedData.length || truncated ? 'removeClass' : 'addClass']('no-results');
 
-      if (searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList && searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
         // Same results returned. Do nothing.
         return Promise.resolve();
       }
@@ -1687,7 +1688,9 @@ DynamicList.prototype.searchData = function(options) {
         _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
       }
 
-      if (searchedData.length && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList
+        && searchedData.length
+        && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
         // Search results is a subset of the current render.
         // Remove the extra records without re-render.
         _this.$container.find(_.map(_.differenceBy(_this.searchedListItems, searchedData, 'id'), function (record) {
@@ -1720,7 +1723,8 @@ DynamicList.prototype.searchData = function(options) {
         showBookmarks: _this.showBookmarks,
         id: _this.data.id,
         uuid: _this.data.uuid,
-        container: _this.$container
+        container: _this.$container,
+        initialRender: !!options.initialRender
       });
     });
     return Fliplet.Hooks.run('flListDataAfterRenderList', {
@@ -1732,7 +1736,8 @@ DynamicList.prototype.searchData = function(options) {
       showBookmarks: _this.showBookmarks,
       id: _this.data.id,
       uuid: _this.data.uuid,
-      container: _this.$container
+      container: _this.$container,
+      initialRender: !!options.initialRender
     });
   });
 }

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -19,6 +19,7 @@ function DynamicList(id, data, container) {
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
   this.data.computedFields = this.data.computedFields || {};
+  this.data.forceRenderList = false;
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
 
   // Other variables
@@ -914,7 +915,7 @@ DynamicList.prototype.parseSearchQueries = function() {
 
   if (!_.get(_this.pvSearchQuery, 'value')) {
     return _this.searchData({
-      query: true
+      initialRender: true
     });
   }
 
@@ -922,7 +923,7 @@ DynamicList.prototype.parseSearchQueries = function() {
     return _this.searchData({
       value: _this.pvSearchQuery.value,
       openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-      query: true
+      initialRender: true
     });
   }
 
@@ -933,7 +934,7 @@ DynamicList.prototype.parseSearchQueries = function() {
     column: _this.pvSearchQuery.column,
     value: _this.pvSearchQuery.value,
     openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-    query: true
+    initialRender: true
   });
 }
 
@@ -1401,7 +1402,7 @@ DynamicList.prototype.searchData = function(options) {
       _this.$container.find('.hidden-search-controls').addClass('active');
       _this.$container.find('.hidden-search-controls')[searchedData.length || truncated ? 'removeClass' : 'addClass']('no-results');
 
-      if (searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList && searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
         // Same results returned. Do nothing.
         return Promise.resolve();
       }
@@ -1410,7 +1411,9 @@ DynamicList.prototype.searchData = function(options) {
         _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
       }
 
-      if (searchedData.length && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList
+        && searchedData.length
+        && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
         // Search results is a subset of the current render.
         // Remove the extra records without re-render.
         _this.$container.find(_.map(_.differenceBy(_this.searchedListItems, searchedData, 'id'), function (record) {
@@ -1442,7 +1445,8 @@ DynamicList.prototype.searchData = function(options) {
           showBookmarks: _this.showBookmarks,
           id: _this.data.id,
           uuid: _this.data.uuid,
-          container: _this.$container
+          container: _this.$container,
+          initialRender: !!options.initialRender
         });
       });
       return Fliplet.Hooks.run('flListDataAfterRenderList', {
@@ -1454,7 +1458,8 @@ DynamicList.prototype.searchData = function(options) {
         showBookmarks: _this.showBookmarks,
         id: _this.data.id,
         uuid: _this.data.uuid,
-        container: _this.$container
+        container: _this.$container,
+        initialRender: !!options.initialRender
       });
     });
   });

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -18,6 +18,7 @@ function DynamicList(id, data, container) {
   this.data = data;
   this.data['summary-fields'] = this.data['summary-fields'] || this.flListLayoutConfig[this.data.layout]['summary-fields'];
   this.data.computedFields = this.data.computedFields || {};
+  this.data.forceRenderList = false;
   this.$container = $('[data-dynamic-lists-id="' + id + '"]');
 
   // Other variables
@@ -772,7 +773,7 @@ DynamicList.prototype.parseSearchQueries = function() {
 
   if (!_.get(_this.pvSearchQuery, 'value')) {
     return _this.searchData({
-      query: true
+      initialRender: true
     });
   }
 
@@ -780,7 +781,7 @@ DynamicList.prototype.parseSearchQueries = function() {
     return _this.searchData({
       value: _this.pvSearchQuery.value,
       openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-      query: true
+      initialRender: true
     });
   }
 
@@ -791,7 +792,7 @@ DynamicList.prototype.parseSearchQueries = function() {
     column: _this.pvSearchQuery.column,
     value: _this.pvSearchQuery.value,
     openSingleEntry: _this.pvSearchQuery.openSingleEntry,
-    query: true
+    initialRender: true
   });
 }
 
@@ -1355,7 +1356,7 @@ DynamicList.prototype.searchData = function(options) {
         .addClass('active')
         [searchedData.length || truncated ? 'removeClass' : 'addClass']('no-results');
 
-      if (searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList && searchedData.length && !_.xorBy(searchedData, _this.searchedListItems, 'id').length) {
         // Same results returned. Do nothing.
         return Promise.resolve();
       }
@@ -1364,7 +1365,9 @@ DynamicList.prototype.searchData = function(options) {
         _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
       }
 
-      if (searchedData.length && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
+      if (!_this.data.forceRenderList
+        && searchedData.length
+        && searchedData.length === _.intersectionBy(searchedData, _this.searchedListItems, 'id').length) {
         // Search results is a subset of the current render.
         // Remove the extra records without re-render.
         _this.$container.find(_.map(_.differenceBy(_this.searchedListItems, searchedData, 'id'), function (record) {
@@ -1410,7 +1413,8 @@ DynamicList.prototype.searchData = function(options) {
           showBookmarks: _this.showBookmarks,
           id: _this.data.id,
           uuid: _this.data.uuid,
-          container: _this.$container
+          container: _this.$container,
+          initialRender: !!options.initialRender
         });
       });
       return Fliplet.Hooks.run('flListDataAfterRenderList', {
@@ -1422,7 +1426,8 @@ DynamicList.prototype.searchData = function(options) {
         showBookmarks: _this.showBookmarks,
         id: _this.data.id,
         uuid: _this.data.uuid,
-        container: _this.$container
+        container: _this.$container,
+        initialRender: !!options.initialRender
       });
     });
   });

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -737,7 +737,8 @@ DynamicList.prototype.renderLoopHTML = function (iterateeCb) {
           Fliplet.Hooks.run('flListDataAfterRenderList', {
             instance: _this,
             records: data,
-            config: _this.data
+            config: _this.data,
+            initialRender: true
           });
           resolve();
         }


### PR DESCRIPTION
- Fixes an issue where bookmarks are initialised multiple times (ref. https://github.com/Fliplet/fliplet-studio/issues/5861)
- Adds `config.forcenRenderList` as an option to force every list item to render instead of simply removing existing entries
- Adds `options.initialRender` as a parameter in `flListDataAfterRenderList` hooks to signify whether the hook is fired from an initial load or subsequent filters