### PR TITLE
Save a user data before reload after datasource closing

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -592,7 +592,7 @@ var DynamicLists = (function() {
       Fliplet.Studio.onMessage(function(event) {
         if (event.data && event.data.event === 'overlay-close' && event.data.data && event.data.data.dataSourceId) {
           // Saving user data before reload interface
-          _this.saveLists()
+          _this.saveLists();
           _this.reloadDataSources().then(function(dataSources) {
             if (!_this.config.dataAlertSeen) {
               return Fliplet.Modal.confirm({

--- a/js/interface.js
+++ b/js/interface.js
@@ -591,6 +591,8 @@ var DynamicLists = (function() {
 
       Fliplet.Studio.onMessage(function(event) {
         if (event.data && event.data.event === 'overlay-close' && event.data.data && event.data.data.dataSourceId) {
+          // Saving user data before reload interface
+          _this.saveLists()
           _this.reloadDataSources().then(function(dataSources) {
             if (!_this.config.dataAlertSeen) {
               return Fliplet.Modal.confirm({


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5394

## Description
Save a user data before reload after datasource closing

## Screenshots/screencasts
https://share.getcloudapp.com/v1urDkDj

## Backward compatibility

This change is fully backward compatible.