### PR TITLE
Added support CSS for the old version of the user templates

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1564,3 +1564,72 @@
     display: none;
   }
 }
+
+
+.agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -1544,3 +1544,72 @@
 .new-news-feed-list-container.ready .news-feed-list-wrapper {
   opacity: 1;
 }
+
+
+.news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -1200,3 +1200,72 @@
 .simple-list-container.ready .simple-list-wrapper {
   opacity: 1;
 }
+
+
+.simple-list-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.simple-list-detail-overlay-close .fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .simple-list-detail-overlay-close .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .simple-list-detail-overlay-close .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .simple-list-detail-overlay-close .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .simple-list-detail-overlay-close .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .simple-list-detail-overlay-close .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .simple-list-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .simple-list-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .simple-list-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1238,3 +1238,71 @@
  .has-bookmarks {
   padding-right: 20px !important;
 }
+
+.small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}

--- a/css/layout-css/small-h-card-style.upload.css
+++ b/css/layout-css/small-h-card-style.upload.css
@@ -567,3 +567,71 @@
     display: none;
   }
 }
+
+.small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 4px;
+  font-size: 0.8em !important;
+}
+
+.small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin::before {
+  content: '\002573';
+}
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+/* Safari layout */
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+      padding-top: 1px;
+      padding-bottom: 0px;
+    }
+  }
+}
+
+/* For native devices */
+.native.android .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+  padding-top: 5px;
+}
+
+.native.ios .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+  padding-top: 1px;
+}
+
+.mode-interact [data-dynamic-lists-id] {
+  min-height: 32px;
+}
+
+/* For MS Edge */
+@supports (-ms-ime-align:auto) {
+  .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+    padding-top: 1px;
+    padding-bottom: 3px;
+  }
+}
+
+/* For Firefox */
+@-moz-document url-prefix() {
+  .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 5px;
+  }
+
+  .no-windows .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* For Android Chrome browser*/
+.android.no-native .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .fa-times-thin {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5469

## Description
Added support CSS for the old version of the user templates

## Backward compatibility

This change is fully backward compatible.

## Notes
These styles are needed to add for the users with the old templates which doesn't have a `.close-icon` class on which we are targeting in the build.css. So to avoid this issue I've duplicated style from build.css to each layout CSS with their unique classes.