### PR TITLE
Users with old templates will also see the close icon on the mobile devices

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1239,19 +1239,19 @@
   padding-right: 20px !important;
 }
 
-.small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+.small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 4px;
   font-size: 0.8em !important;
 }
 
-.small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin::before {
+.small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin::before {
   content: '\002573';
 }
 
 /* IE11 layout */
 @media screen and (-ms-high-contrast: none) {
-  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
     padding-top: 0px;
     padding-bottom: 5px;
   }
@@ -1260,7 +1260,7 @@
 /* Safari layout */
 @media not all and (min-resolution:.001dpcm) {
   @media {
-    .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+    .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
       padding-top: 1px;
       padding-bottom: 0px;
     }
@@ -1268,11 +1268,11 @@
 }
 
 /* For native devices */
-.native.android .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+.native.android .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
   padding-top: 5px;
 }
 
-.native.ios .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+.native.ios .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
   padding-top: 1px;
 }
 
@@ -1282,7 +1282,7 @@
 
 /* For MS Edge */
 @supports (-ms-ime-align:auto) {
-  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
     padding-top: 1px;
     padding-bottom: 3px;
   }
@@ -1290,19 +1290,19 @@
 
 /* For Firefox */
 @-moz-document url-prefix() {
-  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 5px;
   }
 
-  .no-windows .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+  .no-windows .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
     padding-top: 2px;
     padding-bottom: 2px;
   }
 }
 
 /* For Android Chrome browser*/
-.android.no-native .small-card-detail-overlay-wrapper .small-card-detail-overlay-close.tablet .fa-times-thin {
+.android.no-native .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .fa-times-thin {
   padding-top: 2px;
   padding-bottom: 2px;
 }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5469#issuecomment-599418152

## Description
Removed the `.tablet` class from the CSS selector to ensure that we will apply styles for mobile devices as well.

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/76742712-36209f00-677a-11ea-8cb4-0546751cd795.png)


## Backward compatibility

This change is fully backward compatible.