### PR TITLE
Returned CSS code for old templates of the LFD so text would clamp properly

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -779,6 +779,14 @@
   left: 0;
 }
 
+.new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description {	
+  overflow: hidden;	
+  display: -webkit-box;	
+  -webkit-line-clamp: 3;	
+  -webkit-box-orient: vertical;	
+  height: 4.4em;	
+}
+
 .new-news-feed-list-container .slide-over .news-feed-item-inner-content .news-feed-item-description,
 .news-feed-detail-overlay .news-feed-item-inner-content .news-feed-item-description {
   font-size: 16px;

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -558,6 +558,16 @@
   background-repeat: no-repeat;
 }
 
+.simple-list-item .list-item-title,	
+.simple-list-item .list-item-description,	
+.simple-list-item .list-item-subtitle {	
+  margin: 0;	
+  display: -webkit-box;	
+  -webkit-line-clamp: 3;	
+  -webkit-box-orient: vertical;	
+  overflow: hidden;	
+}
+
 .simple-list-item .list-item-title {
   font-size: 18px;
 }

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1491,7 +1491,14 @@ DynamicList.prototype.renderLoopHTML = function (iterateeCb) {
         }
         renderLoopIndex++;
 
-        window.ellipsed.ellipsis('[data-line-clamp]', $('[data-line-clamp]').data('line-clamp'));
+        if (Modernizr.ie11) {
+          // In case if there is no data-line-clamp attribute we should clamp .news-feed-item-description selector with 3 lines
+          var $lineClamp = $('[data-line-clamp]');
+          var selector = $lineClamp.length ? '[data-line-clamp]' : '.news-feed-item-description';
+          var linesToClamp = $lineClamp.length ? $lineClamp.data('line-clamp') : 3;
+
+          window.ellipsed.ellipsis(selector, linesToClamp);
+        }
 
         // if the browser is ready, render
         requestAnimationFrame(render);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1212,7 +1212,14 @@ DynamicList.prototype.renderLoopHTML = function (iterateeCb) {
         }
         renderLoopIndex++;
 
-        window.ellipsed.ellipsis('[data-line-clamp]', $('[data-line-clamp]').data('line-clamp'));
+        if (Modernizr.ie11) {
+          // In case if there is no data-line-clamp attribute we should clamp .list-item-description selector with 3 lines
+          var $lineClamp = $('[data-line-clamp]');
+          var selector = $lineClamp.length ? '[data-line-clamp]' : '.list-item-description';
+          var linesToClamp = $lineClamp.length ? $lineClamp.data('line-clamp') : 3;
+
+          window.ellipsed.ellipsis(selector, linesToClamp);
+        }
 
         // if the browser is ready, render
         requestAnimationFrame(render);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6062

## Description
Returned CSS code for old templates of the LFD so text would clamp properly

## Backward compatibility

This change is fully backward compatible.