### PR TITLE
Search button in the agenda will not go out the borders in the IE11

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1582,6 +1582,11 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .search-holder .btn.search-btn {
+    height: 32px;
+    padding: 6px 12px;
+  }
 }
 
 /* Safari layout */


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5713

## Description
Search button in the agenda will not go out the borders in the IE11

## Screenshots/screencasts
![search button ie11](https://user-images.githubusercontent.com/53430352/77311027-02102580-6d08-11ea-9b3b-04d454940ce2.png)


## Backward compatibility

This change is fully backward compatible.

## Note
Button text set to white is because when I tested it I've changed the data-widget-package and CSS code doesn't apply.
When we merge it text color will be normal. 