### PR TITLE
Fixes an issue where filters are not correctly retrieved for LFDs with custom JavaScript before #334

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -826,7 +826,7 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function(records) {
-      _this.listItems = _this.getPermissions(records);
+      _this.listItems = records;
 
       return _this.Utils.Records.getFields(_this.listItems, _this.data.dataSourceId).then(function (columns) {
         _this.dataSourceColumns = columns;
@@ -1129,8 +1129,6 @@ DynamicList.prototype.addSummaryData = function(records) {
       id: entry.id,
       flClasses: entry.data['flClasses'],
       flFilters: entry.data['flFilters'],
-      editEntry: entry.editEntry,
-      deleteEntry: entry.deleteEntry,
       pollButton: _this.data.pollEnabled
         && entry.data[_this.data.pollColumn]
         && entry.data[_this.data.pollColumn] !== '',
@@ -1344,16 +1342,16 @@ DynamicList.prototype.getAddPermission = function(data) {
   return data;
 }
 
-DynamicList.prototype.getPermissions = function(entries) {
-  var _this = this;
+DynamicList.prototype.addPermissions = function(entry) {
+  if (!_.isObject(entry)) {
+    return entry;
+  }
 
   // Adds flag for Edit and Delete buttons
-  _.forEach(entries, function (entry) {
-    entry.editEntry = _this.Utils.Record.isEditable(entry, _this.data, _this.myUserData);
-    entry.deleteEntry = _this.Utils.Record.isDeletable(entry, _this.data, _this.myUserData);
-  });
+  entry.editEntry = this.Utils.Record.isEditable(entry, this.data, this.myUserData);
+  entry.deleteEntry = this.Utils.Record.isDeletable(entry, this.data, this.myUserData);
 
-  return entries;
+  return entry;
 }
 
 DynamicList.prototype.addFilters = function(records) {
@@ -2206,6 +2204,7 @@ DynamicList.prototype.addDetailViewData = function (entry) {
     return option.editable;
   });
 
+  entry = _this.addPermissions(entry);
   entry.entryDetails = [];
 
   // Uses detail view settings not set by users

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -36,6 +36,7 @@ function DynamicList(id, data, container) {
   this.agendaDates = [];
   this.showBookmarks;
   this.fetchedAllBookmarks = false;
+  this.allFilterPropertiesAdded = false;
   this.searchValue = '';
   this.activeFilters = {};
 
@@ -843,11 +844,12 @@ DynamicList.prototype.initialize = function() {
     .then(function(response) {
       _this.listItems = _.uniqBy(response, 'id');
       _this.checkIsToOpen();
-      _this.modifiedListItems = _this.Utils.Records.addFilterProperties({
+      _this.listItems = _this.Utils.Records.addFilterProperties({
         records: _this.listItems,
         config: _this.data
       });
-      return _this.addFilters(_this.modifiedListItems);
+      _this.allFilterPropertiesAdded = true;
+      return _this.addFilters(_this.listItems);
     }).then(function () {
       _this.parseFilterQueries();
       _this.parseSearchQueries();
@@ -1112,10 +1114,14 @@ DynamicList.prototype.groupLoopDataByDate = function (loopData, dateField) {
 
 DynamicList.prototype.addSummaryData = function(records) {
   var _this = this;
-  var modifiedData = _this.Utils.Records.addFilterProperties({
-    records: records,
-    config: _this.data
-  });
+  var modifiedData = records;
+
+  if (!_this.allFilterPropertiesAdded) {
+    modifiedData = _this.Utils.Records.addFilterProperties({
+      records: modifiedData,
+      config: _this.data
+    });
+  }
 
   // Uses sumamry view settings set by users
   var loopData = _.map(modifiedData, function(entry) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -41,6 +41,7 @@ function DynamicList(id, data, container) {
   this.isSearching;
   this.showBookmarks;
   this.fetchedAllBookmarks = false;
+  this.allFilterPropertiesAdded = false;
   this.searchValue = '';
   this.activeFilters = {};
 
@@ -1063,11 +1064,12 @@ DynamicList.prototype.initialize = function() {
     .then(function(response) {
       _this.listItems = _.uniqBy(response, 'id');
       _this.checkIsToOpen();
-      _this.modifiedListItems = _this.Utils.Records.addFilterProperties({
+      _this.listItems = _this.Utils.Records.addFilterProperties({
         records: _this.listItems,
         config: _this.data
       });
-      return _this.addFilters(_this.modifiedListItems);
+      _this.allFilterPropertiesAdded = true;
+      return _this.addFilters(_this.listItems);
     })
     .then(function () {
       _this.parseFilterQueries();
@@ -1335,10 +1337,15 @@ DynamicList.prototype.renderBaseHTML = function() {
 
 DynamicList.prototype.addSummaryData = function(records) {
   var _this = this;
-  var modifiedData = _this.Utils.Records.addFilterProperties({
-    records: records,
-    config: _this.data
-  });
+  var modifiedData = records;
+
+  if (!_this.allFilterPropertiesAdded) {
+    modifiedData = _this.Utils.Records.addFilterProperties({
+      records: modifiedData,
+      config: _this.data
+    });
+  }
+
   var loopData = _.map(modifiedData, function(entry) {
     var newObject = {
       id: entry.id,

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -982,13 +982,12 @@ DynamicList.prototype.getCommentUsers = function () {
 
       // Update my user data
       if (_this.myUserData) {
-        var myUser = _.find(_this.allUsers, function(user) {
-          return _this.myUserData[_this.data.userEmailColumn] === user.data[_this.data.userEmailColumn];
+        _this.allUsers.some(function (user) {
+          if (_this.myUserData[_this.data.userEmailColumn] === user.data[_this.data.userEmailColumn]) {
+            _this.myUserData = $.extend(true, _this.myUserData, user.data);
+            return true;
+          }
         });
-
-        if (myUser) {
-          _this.myUserData = $.extend(true, _this.myUserData, myUser.data);
-        }
       }
 
       return _this.Utils.Users.getUsersToMention({
@@ -1045,7 +1044,7 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function (records) {
-      _this.listItems = _this.getPermissions(records);
+      _this.listItems = records;
 
       if (!_this.data.detailViewAutoUpdate) {
         return Promise.resolve();
@@ -1351,8 +1350,6 @@ DynamicList.prototype.addSummaryData = function(records) {
       id: entry.id,
       flClasses: entry.data['flClasses'],
       flFilters: entry.data['flFilters'],
-      editEntry: entry.editEntry,
-      deleteEntry: entry.deleteEntry,
       likesEnabled: entry.likesEnabled,
       bookmarksEnabled: entry.bookmarksEnabled,
       commentsEnabled: entry.commentsEnabled,
@@ -1442,16 +1439,16 @@ DynamicList.prototype.getAddPermission = function(data) {
   return data;
 }
 
-DynamicList.prototype.getPermissions = function(entries) {
-  var _this = this;
+DynamicList.prototype.addPermissions = function(entry) {
+  if (!_.isObject(entry)) {
+    return entry;
+  }
 
   // Adds flag for Edit and Delete buttons
-  _.forEach(entries, function (entry) {
-    entry.editEntry = _this.Utils.Record.isEditable(entry, _this.data, _this.myUserData);
-    entry.deleteEntry = _this.Utils.Record.isDeletable(entry, _this.data, _this.myUserData);
-  });
+  entry.editEntry = this.Utils.Record.isEditable(entry, this.data, this.myUserData);
+  entry.deleteEntry = this.Utils.Record.isDeletable(entry, this.data, this.myUserData);
 
-  return entries;
+  return entry;
 }
 
 DynamicList.prototype.addFilters = function(records) {
@@ -1918,6 +1915,7 @@ DynamicList.prototype.addDetailViewData = function (entry) {
     return entry;
   }
 
+  entry = _this.addPermissions(entry);
   entry.entryDetails = [];
 
   // Define detail view data based on user's settings

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -33,6 +33,7 @@ function DynamicList(id, data, container) {
   this.isSearching;
   this.showBookmarks;
   this.fetchedAllBookmarks = false;
+  this.allFilterPropertiesAdded = false;
 
   this.listItems;
   this.modifiedListItems;
@@ -858,11 +859,12 @@ DynamicList.prototype.initialize = function() {
     .then(function(response) {
       _this.listItems = _.uniqBy(response, 'id');
       _this.checkIsToOpen();
-      _this.modifiedListItems = _this.Utils.Records.addFilterProperties({
+      _this.listItems = _this.Utils.Records.addFilterProperties({
         records: _this.listItems,
         config: _this.data
       });
-      return _this.addFilters(_this.modifiedListItems);
+      _this.allFilterPropertiesAdded = true;
+      return _this.addFilters(_this.listItems);
     })
     .then(function () {
       _this.parseFilterQueries();
@@ -1126,10 +1128,15 @@ DynamicList.prototype.renderBaseHTML = function() {
 
 DynamicList.prototype.addSummaryData = function(records) {
   var _this = this;
-  var modifiedData = _this.Utils.Records.addFilterProperties({
-    records: records,
-    config: _this.data
-  });
+  var modifiedData = records;
+
+  if (!_this.allFilterPropertiesAdded) {
+    modifiedData = _this.Utils.Records.addFilterProperties({
+      records: modifiedData,
+      config: _this.data
+    });
+  }
+
   var loopData = _.map(modifiedData, function(entry) {
     var newObject = {
       id: entry.id,

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -28,6 +28,7 @@ function DynamicList(id, data, container) {
   this.isSearching;
   this.showBookmarks;
   this.fetchedAllBookmarks = false;
+  this.allFilterPropertiesAdded = false;
 
   this.emailField = 'Email';
   this.myProfileData = [];
@@ -690,11 +691,12 @@ DynamicList.prototype.initialize = function() {
       // Get user profile
       if (_this.myUserData) {
         // Create flag for current user
-        records.forEach(function(record) {
+        records.some(function(record) {
           record.isCurrentUser = _this.Utils.Record.isCurrentUser(record, _this.data, _this.myUserData);
 
           if (record.isCurrentUser) {
             _this.myProfileData.push(record);
+            return true;
           }
         });
       }
@@ -719,11 +721,12 @@ DynamicList.prototype.initialize = function() {
     .then(function(response) {
       _this.listItems = _.uniqBy(response, 'id');
       _this.checkIsToOpen();
-      _this.modifiedListItems = _this.Utils.Records.addFilterProperties({
+      _this.listItems = _this.Utils.Records.addFilterProperties({
         records: _this.listItems,
         config: _this.data
       });
-      return _this.addFilters(_this.modifiedListItems);
+      _this.allFilterPropertiesAdded = true;
+      return _this.addFilters(_this.listItems);
     })
     .then(function () {
       _this.parseFilterQueries();
@@ -987,10 +990,15 @@ DynamicList.prototype.renderBaseHTML = function() {
 
 DynamicList.prototype.addSummaryData = function(records, forProfile) {
   var _this = this;
-  var modifiedData = _this.Utils.Records.addFilterProperties({
-    records: records,
-    config: _this.data
-  });
+  var modifiedData = records;
+
+  if (!_this.allFilterPropertiesAdded) {
+    modifiedData = _this.Utils.Records.addFilterProperties({
+      records: modifiedData,
+      config: _this.data
+    });
+  }
+
   var loopData = _.map(modifiedData, function(entry) {
     var newObject = {
       id: entry.id,

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -686,8 +686,6 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function (records) {
-      records = _this.getPermissions(records);
-
       // Get user profile
       if (_this.myUserData) {
         // Create flag for current user
@@ -1004,8 +1002,6 @@ DynamicList.prototype.addSummaryData = function(records, forProfile) {
       id: entry.id,
       flClasses: entry.data['flClasses'],
       flFilters: entry.data['flFilters'],
-      editEntry: entry.editEntry,
-      deleteEntry: entry.deleteEntry,
       isCurrentUser: entry.isCurrentUser ? entry.isCurrentUser : false,
       bookmarksEnabled: entry.bookmarksEnabled,
       entryDetails: [],
@@ -1084,16 +1080,16 @@ DynamicList.prototype.getAddPermission = function(data) {
   return data;
 }
 
-DynamicList.prototype.getPermissions = function(entries) {
-  var _this = this;
+DynamicList.prototype.addPermissions = function(entry) {
+  if (!_.isObject(entry)) {
+    return entry;
+  }
 
   // Adds flag for Edit and Delete buttons
-  _.forEach(entries, function (entry) {
-    entry.editEntry = _this.Utils.Record.isEditable(entry, _this.data, _this.myUserData);
-    entry.deleteEntry = _this.Utils.Record.isDeletable(entry, _this.data, _this.myUserData);
-  });
+  entry.editEntry = this.Utils.Record.isEditable(entry, this.data, this.myUserData);
+  entry.deleteEntry = this.Utils.Record.isDeletable(entry, this.data, this.myUserData);
 
-  return entries;
+  return entry;
 }
 
 DynamicList.prototype.addFilters = function(records) {
@@ -1557,6 +1553,7 @@ DynamicList.prototype.addDetailViewData = function (entry) {
     return option.editable;
   });
 
+  entry = _this.addPermissions(entry);
   entry.entryDetails = [];
 
   // Uses detail view settings not set by users

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -22,7 +22,6 @@ function DynamicList(id, data, container) {
   this.allowClick = true;
 
   this.emailField = 'Email';
-  this.myProfileData;
   this.modifiedProfileData;
   this.myUserData;
 
@@ -381,20 +380,6 @@ DynamicList.prototype.initialize = function() {
       });
     })
     .then(function (records) {
-      records = _this.getPermissions(records);
-
-      // Get user profile
-      if (_this.myUserData) {
-        // Create flag for current user
-        records.forEach(function(record) {
-          record.isCurrentUser = _this.Utils.Record.isCurrentUser(record, _this.data, _this.myUserData);
-        });
-
-        _this.myProfileData = _.filter(records, function(row) {
-          return row.isCurrentUser;
-        });
-      }
-
       // Make rows available Globally
       _this.listItems = records;
 
@@ -574,8 +559,6 @@ DynamicList.prototype.addSummaryData = function(records) {
   var loopData = _.map(records, function(entry) {
     var newObject = {
       id: entry.id,
-      editEntry: entry.editEntry,
-      deleteEntry: entry.deleteEntry,
       isCurrentUser: entry.isCurrentUser ? entry.isCurrentUser : false,
       entryDetails: [],
       originalData: entry.data
@@ -656,16 +639,16 @@ DynamicList.prototype.getAddPermission = function(data) {
   return data;
 }
 
-DynamicList.prototype.getPermissions = function(entries) {
-  var _this = this;
+DynamicList.prototype.addPermissions = function(entry) {
+  if (!_.isObject(entry)) {
+    return entry;
+  }
 
   // Adds flag for Edit and Delete buttons
-  _.forEach(entries, function (entry) {
-    entry.editEntry = _this.Utils.Record.isEditable(entry, _this.data, _this.myUserData);
-    entry.deleteEntry = _this.Utils.Record.isDeletable(entry, _this.data, _this.myUserData);
-  });
+  entry.editEntry = this.Utils.Record.isEditable(entry, this.data, this.myUserData);
+  entry.deleteEntry = this.Utils.Record.isDeletable(entry, this.data, this.myUserData);
 
-  return entries;
+  return entry;
 }
 
 DynamicList.prototype.addDetailViewData = function (entry) {
@@ -682,6 +665,7 @@ DynamicList.prototype.addDetailViewData = function (entry) {
     return option.editable;
   });
 
+  entry = _this.addPermissions(entry);
   entry.entryDetails = [];
 
   // Uses detail view settings not set by users

--- a/js/utils.js
+++ b/js/utils.js
@@ -668,7 +668,9 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     // Parse legacy flFilters from records to generate a list of filter values
     return _(records)
-      .map('data.flFilters')
+      .map(function (record) {
+        return (record.data && record.data.flFilters) || record.flFilters;
+      })
       .flatten()
       .uniqBy(function (filter) {
         // _.uniqBy iteratee


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6145

The #334 PR mistakenly changed the assumed data structure for filter data in the `parseRecordFilters()` function in `utils.js`. This updates it so that it checks for both data structure formats.

Unfortunately, we can't simply revert the change since some LFD instances could have locked down the changes using custom JS.