### PR TITLE
Fixes a compatibility issue between versions of record processing code

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -668,7 +668,9 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     // Parse legacy flFilters from records to generate a list of filter values
     return _(records)
-      .map('data.flFilters')
+      .map(function (record) {
+        return (record.data && record.data.flFilters) || record.flFilters;
+      })
       .flatten()
       .uniqBy(function (filter) {
         // _.uniqBy iteratee


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6145

The #334 PR mistakenly changed the assumed data structure for filter data in the `parseRecordFilters()` function in `utils.js`. This updates it so that it checks for both data structure formats.

Unfortunately, we can't simply revert the change since some LFD instances could have locked down the changes using custom JS.