### PR TITLE
The close icon on an old template on windows 7 will look normal with ie11

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1593,6 +1593,18 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .win7.fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 1px;
+    font-weight: lighter;
+    font-size: 1.2em !important;
+  }
+
+  .agenda-detail-overlay-wrapper .agenda-detail-overlay-close .win7.fa-times-thin::before {
+    content: '\2715';
+  }
+
 }
 
 /* Safari layout */

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -1570,6 +1570,18 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .win7.fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 1px;
+    font-weight: lighter;
+    font-size: 1.2em !important;
+  }
+
+  .news-feed-detail-overlay-wrapper .news-feed-detail-overlay-close .win7.fa-times-thin::before {
+    content: '\2715';
+  }
+
 }
 
 /* Safari layout */

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -1228,6 +1228,18 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .simple-list-detail-overlay-close .win7.fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 1px;
+    font-weight: lighter;
+    font-size: 1.2em !important;
+  }
+
+  .simple-list-detail-overlay-close .win7.fa-times-thin::before {
+    content: '\2715';
+  }
+
 }
 
 /* Safari layout */

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1255,6 +1255,18 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .win7.fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 1px;
+    font-weight: lighter;
+    font-size: 1.2em !important;
+  }
+
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-close .win7.fa-times-thin::before {
+    content: '\2715';
+  }
+  
 }
 
 /* Safari layout */

--- a/css/layout-css/small-h-card-style.upload.css
+++ b/css/layout-css/small-h-card-style.upload.css
@@ -584,6 +584,18 @@
     padding-top: 0px;
     padding-bottom: 5px;
   }
+
+  .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .win7.fa-times-thin {
+    padding-top: 2px;
+    padding-bottom: 1px;
+    font-weight: lighter;
+    font-size: 1.2em !important;
+  }
+
+  .small-h-card-detail-overlay-wrapper .small-h-card-detail-overlay-close .win7.fa-times-thin::before {
+    content: '\2715';
+  }
+
 }
 
 /* Safari layout */

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1235,6 +1235,12 @@ DynamicList.prototype.renderLoopHTML = function () {
       // if the browser is ready, render
       requestAnimationFrame(render);
     }
+
+    // Changing close icon in the fa-times-thin class for windows 7 IE11
+    if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
+      $('.fa-times-thin').addClass('win7');
+    }
+
     // start the initial render
     requestAnimationFrame(render);
   });

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1422,6 +1422,12 @@ DynamicList.prototype.renderLoopHTML = function () {
         requestAnimationFrame(render);
       } else {
         _this.$container.find('.new-news-feed-list-container').removeClass('loading').addClass('ready');
+
+        // Changing close icon in the fa-times-thin class for windows 7 IE11
+        if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
+          $('.fa-times-thin').addClass('win7');
+        }        
+
         resolve(data);
       }
     }

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1212,6 +1212,12 @@ DynamicList.prototype.renderLoopHTML = function () {
         requestAnimationFrame(render);
       } else{
         _this.$container.find('.simple-list-container').removeClass('loading').addClass('ready');
+
+        // Changing close icon in the fa-times-thin class for windows 7 IE11
+        if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
+          $('.fa-times-thin').addClass('win7');
+        }
+
         resolve(data);
       }
     }

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1063,6 +1063,12 @@ DynamicList.prototype.renderLoopHTML = function () {
         requestAnimationFrame(render);
       } else {
         _this.$container.find('.new-small-card-list-container').removeClass('loading').addClass('ready');
+
+        // Changing close icon in the fa-times-thin class for windows 7 IE11
+        if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
+          $('.fa-times-thin').addClass('win7');
+        }
+
         resolve(data);
       }
     }

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -645,6 +645,12 @@ DynamicList.prototype.renderLoopHTML = function (iterateeCb) {
           resolve();
         }
       }
+
+      // Changing close icon in the fa-times-thin class for windows 7 IE11
+      if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
+        $('.fa-times-thin').addClass('win7');
+      }
+    
       // start the initial render
       requestAnimationFrame(render);
     });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6067

## Description
The close icon on an old template on windows 7 will look normal with ie11

## Screenshots/screencasts
![IE11 newsfeed](https://user-images.githubusercontent.com/53430352/77893570-c384e880-727c-11ea-9ca4-e6855eeca4bf.png)
![IE11 simple list](https://user-images.githubusercontent.com/53430352/77893582-c5e74280-727c-11ea-892f-66e0a10379b6.png)
![IE11 Agenda](https://user-images.githubusercontent.com/53430352/77893587-c67fd900-727c-11ea-8d65-79216ee46586.png)
![IE11 directory](https://user-images.githubusercontent.com/53430352/77893590-c7186f80-727c-11ea-973d-cd1c7a4d0697.png)
![IE11 fetured](https://user-images.githubusercontent.com/53430352/77893594-c8499c80-727c-11ea-8dfc-fedfd218000b.png)


## Backward compatibility

This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 