### PR TITLE
Ensures detail view doesn't open in edit mode

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -824,7 +824,7 @@
   width: 100%;
   text-align: left;
   cursor: default;
-  pointer-events: all;
+  pointer-events: none;
   background-color: #ffffff;
   overflow: hidden;
   -webkit-transform: translate3d(0,0,0);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5601

## Description
The detail view will not open in edit mode

## Screenshots/screencasts
https://share.getcloudapp.com/Apur2dX4

## Backward compatibility

This change is fully backward compatible.