### PR TITLE
LFD hooks and query parameters for comments

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -1064,11 +1064,11 @@
 }
 
 .new-news-feed-comment-panel .news-feed-comment-area {
-  height: calc(100% - 148px);
+  height: calc(100% - 159px);
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0 15px;
-  margin: 54px 0 109px;
+  margin: 54px 0 105px;
   padding-bottom: env(safe-area-inset-bottom);
   z-index: 1;
 }

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -801,11 +801,11 @@
 }
 
 .simple-list-comment-panel .simple-list-comment-area {
-  height: calc(100% - 148px);
+  height: calc(100% - 159px);
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0 15px;
-  margin: 54px 0 109px;
+  margin: 54px 0 105px;
   padding-bottom: env(safe-area-inset-bottom);
   z-index: 1;
 }

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2240,7 +2240,8 @@ DynamicList.prototype.showComments = function(id, commentId) {
     });
   }).then(function() {
     // Get comments for entry
-    var entryComments = _.get(_.find(_this.listItems, { id: id }), 'comments');
+    var entry = _.find(_this.listItems, { id: id });
+    var entryComments = _.get(entry, 'comments');
 
     // Display comments
     entryComments.forEach(function(entry, index) {
@@ -2302,10 +2303,14 @@ DynamicList.prototype.showComments = function(id, commentId) {
     var hookData = {
       instance: _this,
       config: _this.data,
+      id: _this.data.id,
+      uuid: _this.data.uuid,
+      container: _this.$container,
       html: commentsHTML,
       src: commentsTemplate,
       comments: entryComments,
-      entryId: id
+      entryId: id,
+      record: entry
     };
 
     return Fliplet.Hooks.run('flListDataBeforeShowComments', hookData).then(function () {
@@ -2313,9 +2318,13 @@ DynamicList.prototype.showComments = function(id, commentId) {
       return Fliplet.Hooks.run('flListDataAfterShowComments', {
         instance: _this,
         config: _this.data,
+        id: _this.data.id,
+        uuid: _this.data.uuid,
+        container: _this.$container,
         html: commentsHTML,
         comments: entryComments,
-        entryId: id
+        entryId: id,
+        record: entry
       }).then(function () {
         var scrollTop = $commentArea[0].scrollHeight;
 
@@ -2377,6 +2386,7 @@ DynamicList.prototype.sendComment = function(id, value) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: record,
     comment: value,
     commentGuid: guid
   };
@@ -2464,6 +2474,7 @@ DynamicList.prototype.sendComment = function(id, value) {
           id: _this.data.id,
           uuid: _this.data.uuid,
           container: _this.$container,
+          record: record,
           commentEntry: comment,
           commentGuid: guid
         };
@@ -2595,6 +2606,7 @@ DynamicList.prototype.deleteComment = function(id) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: entry,
     commentId: id,
     commentContainer: commentHolder
   };
@@ -2639,9 +2651,9 @@ DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: entry,
     oldCommentData: oldCommentData,
-    newComment: newComment,
-    commentId: commentId
+    newComment: newComment
   };
 
   return Fliplet.Hooks.run('flListDataBeforeUpdateComment', options)
@@ -2670,9 +2682,9 @@ DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
             id: _this.data.id,
             uuid: _this.data.uuid,
             container: _this.$container,
+            record: entry,
             oldCommentData: oldCommentData,
-            newCommentData: newCommentData,
-            commentId: commentId
+            newCommentData: newCommentData
           };
           return Fliplet.Hooks.run('flListDataAfterUpdateComment', options)
             .then(function () {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2447,9 +2447,8 @@ DynamicList.prototype.sendComment = function(id, value) {
             options.commentContainer = _this.$container.find('.fl-individual-comment[data-id="' + comment.id + '"]');
             Fliplet.Hooks.run('flListDataAfterNewCommentShown', options);
           });
-      })
-  })
-  .catch(function (error) {
+      });
+  }).catch(function (error) {
     // Reverses count if error occurs
     console.error(error);
 
@@ -2649,8 +2648,9 @@ DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
           };
           return Fliplet.Hooks.run('flListDataAfterUpdateComment', options)
             .then(function () {
-              _this.replaceComment(commentId, options.newCommentData, 'final');
-              options.commentContainer = _this.$container.find('.fl-individual-comment[data-id="' + comment.id + '"]');
+              newCommentData = options.newCommentData;
+              _this.replaceComment(commentId, newCommentData, 'final');
+              options.commentContainer = _this.$container.find('.fl-individual-comment[data-id="' + newCommentData.id + '"]');
               Fliplet.Hooks.run('flListDataAfterUpdateCommentShown', options);
             });
         });

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2265,6 +2265,12 @@ DynamicList.prototype.showComments = function(id) {
 }
 
 DynamicList.prototype.sendComment = function(id, value) {
+  var record = _.find(this.listItems, { id: id });
+
+  if (!record) {
+    return Promise.resolve();
+  }
+
   var _this = this;
   var guid = Fliplet.guid();
   var userName = '';
@@ -2292,99 +2298,124 @@ DynamicList.prototype.sendComment = function(id, value) {
     });
   }
 
-  _this.appendTempComment(id, value, guid, userFromDataSource);
-
-  var record = _.find(_this.listItems, { id: id });
-
-  if (!record) {
-    return Promise.resolve();
-  }
-
-  if (_.get(record, 'commentCount')) {
-    record.commentCount++;
-  }
-
-  _this.updateCommentCounter({
-    id: id,
-    record: record
-  });
-
-  userName = _.compact(_.map(_this.data.userNameFields, function (name) {
-    return _this.myUserData.isSaml2
-      ? _.get(userFromDataSource, 'data.' + name)
-      : _this.myUserData[name];
-  })).join(' ').trim();
-
-  var comment = {
-    fromName: userName,
-    user: _this.myUserData.isSaml2 ? userFromDataSource.data : _this.myUserData
+  var options = {
+    instance: _this,
+    config: _this.data,
+    id: _this.data.id,
+    uuid: _this.data.uuid,
+    container: _this.$container,
+    comment: value,
+    commentGuid: guid
   };
 
-  _.assignIn(comment, { contentDataSourceEntryId: id });
+  return Fliplet.Hooks.run('flListDataBeforeNewComment', options).then(function () {
+    value = options.comment;
+    guid = options.commentGuid;
 
-  var query;
+    if (!value) {
+      return Promise.resolve();
+    }
 
-  var timestamp = (new Date()).toISOString();
+    _this.appendTempComment(id, value, guid, userFromDataSource);
 
-  // Get mentioned user(s)
-  var mentionRegexp = /\B@[a-z0-9_-]+/ig;
-  var mentions = value.match(mentionRegexp);
-  var usersMentioned = [];
+    if (_.get(record, 'commentCount')) {
+      record.commentCount++;
+    }
 
-  if (mentions && mentions.length) {
-    var filteredUsers = _.filter(_this.usersToMention, function(userToMention) {
-      return mentions.indexOf('@' + userToMention.username) > -1;
+    _this.updateCommentCounter({
+      id: id,
+      record: record
     });
 
-    if (filteredUsers && filteredUsers.length) {
-      filteredUsers.forEach(function(filteredUser) {
-        var foundUser = _.find(_this.allUsers, function(user) {
-          return user.id === filteredUser.id;
-        });
+    userName = _.compact(_.map(_this.data.userNameFields, function (name) {
+      return _this.myUserData.isSaml2
+        ? _.get(userFromDataSource, 'data.' + name)
+        : _this.myUserData[name];
+    })).join(' ').trim();
 
-        if (foundUser) {
-          usersMentioned.push(foundUser);
-        }
+    var comment = {
+      fromName: userName,
+      user: _this.myUserData.isSaml2 ? userFromDataSource.data : _this.myUserData
+    };
+
+    _.assignIn(comment, { contentDataSourceEntryId: id });
+
+    var timestamp = (new Date()).toISOString();
+
+    // Get mentioned user(s)
+    var mentionRegexp = /\B@[a-z0-9_-]+/ig;
+    var mentions = value.match(mentionRegexp);
+    var usersMentioned = [];
+
+    if (mentions && mentions.length) {
+      var filteredUsers = _.filter(_this.usersToMention, function(userToMention) {
+        return mentions.indexOf('@' + userToMention.username) > -1;
+      });
+
+      if (filteredUsers && filteredUsers.length) {
+        filteredUsers.forEach(function(filteredUser) {
+          var foundUser = _.find(_this.allUsers, function(user) {
+            return user.id === filteredUser.id;
+          });
+
+          if (foundUser) {
+            usersMentioned.push(foundUser);
+          }
+        });
+      }
+    }
+
+    comment.mentions = [];
+    if (usersMentioned && usersMentioned.length) {
+      usersMentioned.forEach(function(user) {
+        comment.mentions.push(user.id);
       });
     }
-  }
 
-  comment.mentions = [];
-  if (usersMentioned && usersMentioned.length) {
-    usersMentioned.forEach(function(user) {
-      comment.mentions.push(user.id);
-    });
-  }
+    comment.text = value;
+    comment.timestamp = timestamp;
 
-  comment.text = value;
-  comment.timestamp = timestamp;
-
-  return _this.getCommentIdentifier(record)
-    .then(function (identifier) {
-      return Fliplet.Profile.Content({ dataSourceId: _this.data.commentsDataSourceId })
-        .then(function(instance) {
-          return instance.create(identifier, {
-            settings: comment
-          })
-        });
-    })
-    .then(function(comment) {
-      record.comments.push(comment);
-      _this.replaceComment(guid, comment, 'final');
-    })
-    .catch(function onQueryError(error) {
-      // Reverses count if error occurs
-      console.error(error);
-
-      if (_.get(record, 'commentCount')) {
-        record.commentCount--;
-      }
-
-      _this.updateCommentCounter({
-        id: id,
-        record: record
+    return _this.getCommentIdentifier(record)
+      .then(function (identifier) {
+        return Fliplet.Profile.Content({ dataSourceId: _this.data.commentsDataSourceId })
+          .then(function(instance) {
+            return instance.create(identifier, {
+              settings: comment
+            });
+          });
+      })
+      .then(function(comment) {
+        options = {
+          instance: _this,
+          config: _this.data,
+          id: _this.data.id,
+          uuid: _this.data.uuid,
+          container: _this.$container,
+          commentEntry: comment,
+          commentGuid: guid
+        };
+        return Fliplet.Hooks.run('flListDataAfterNewComment', options)
+          .then(function () {
+            comment = options.commentEntry || comment;
+            record.comments.push(comment);
+            _this.replaceComment(guid, comment, 'final');
+            options.commentContainer = _this.$container.find('.fl-individual-comment[data-id="' + comment.id + '"]');
+            Fliplet.Hooks.run('flListDataAfterNewCommentShown', options);
+          });
       });
+  }).catch(function (error) {
+    // Reverses count if error occurs
+    console.error(error);
+
+    if (_.get(record, 'commentCount')) {
+      record.commentCount--;
+    }
+
+    _this.updateCommentCounter({
+      id: id,
+      record: record
     });
+  });
 }
 
 DynamicList.prototype.appendTempComment = function(id, value, guid, userFromDataSource) {
@@ -2485,47 +2516,104 @@ DynamicList.prototype.deleteComment = function(id) {
   var entryId = _this.$container.find('.simple-list-item.open').data('entry-id') || _this.entryClicked;
   var entry = _.find(_this.listItems, { id: entryId });
   var commentHolder = _this.$container.find('.fl-individual-comment[data-id="' + id + '"]');
+  var options = {
+    instance: _this,
+    config: _this.data,
+    id: _this.data.id,
+    uuid: _this.data.uuid,
+    container: _this.$container,
+    commentId: id,
+    commentContainer: commentHolder
+  };
 
-  return Fliplet.DataSources.connect(_this.data.commentsDataSourceId).then(function (connection) {
-    return connection.removeById(id, { ack: true });
-  }).then(function onRemove() {
-    _.remove(entry.comments, { id: id });
-    entry.commentCount--;
-    _this.updateCommentCounter({
-      id: entryId,
-      record: entry
+  commentHolder.hide();
+
+  return Fliplet.Hooks.run('flListDataBeforeDeleteComment', options).then(function () {
+    return Fliplet.DataSources.connect(_this.data.commentsDataSourceId).then(function (connection) {
+      return connection.removeById(id, { ack: true });
+    }).then(function onRemove() {
+      _.remove(entry.comments, { id: id });
+      entry.commentCount--;
+      _this.updateCommentCounter({
+        id: entryId,
+        record: entry
+      });
+      commentHolder.remove();
+      Fliplet.Hooks.run('flListDataAfterDeleteComment', options);
     });
-    commentHolder.remove();
+  }).catch(function (error) {
+    commentHolder.show();
+    Fliplet.UI.Toast.error(error, {
+      message: 'Error deleting comment'
+    });
   });
 }
 
-DynamicList.prototype.saveComment = function(entryId, commentId, value) {
+DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
   var _this = this;
-  var entryComments = _.get(_.find(_this.listItems, { id: entryId }), 'comments', []);
-  var commentData = _.find(entryComments.entries, function(comment) {
-    return comment.id === commentId;
-  });
+  var entry = _.find(_this.listItems, { id: entryId });
+  var entryComments = _.get(entry, 'comments', []);
+  var commentData = _.find(entryComments, { id: commentId });
 
-  if (entryComments) {
-    commentData = _.find(entryComments, function(comment) {
-      return comment.id === commentId;
-    });
+  if (!commentData) {
+    return Promise.reject('Comment not found');
   }
 
-  if (commentData) {
-    commentData.data.settings.text = value;
-    _this.replaceComment(commentId, commentData, 'temp');
-  }
+  var oldCommentData = _.clone(commentData);
+  var options = {
+    instance: _this,
+    config: _this.data,
+    id: _this.data.id,
+    uuid: _this.data.uuid,
+    container: _this.$container,
+    oldCommentData: oldCommentData,
+    newComment: newComment,
+    commentId: commentId
+  };
 
-  Fliplet.Content({dataSourceId: _this.data.commentsDataSourceId})
-    .then(function(instance) {
-      return instance.update({
-        settings: commentData.data.settings
-      }, {
-        id: commentId
-      });
+  return Fliplet.Hooks.run('flListDataBeforeUpdateComment', options)
+    .then(function () {
+      newComment = options.newComment;
+
+      if (!newComment) {
+        return Promise.resolve();
+      }
+
+      commentData.data.settings.text = newComment;
+      _this.replaceComment(commentId, commentData, 'temp');
+
+      return Fliplet.Content({ dataSourceId: _this.data.commentsDataSourceId })
+        .then(function(instance) {
+          return instance.update({
+            settings: commentData.data.settings
+          }, {
+            id: commentId
+          });
+        })
+        .then(function(newCommentData) {
+          options = {
+            instance: _this,
+            config: _this.data,
+            id: _this.data.id,
+            uuid: _this.data.uuid,
+            container: _this.$container,
+            oldCommentData: oldCommentData,
+            newCommentData: newCommentData,
+            commentId: commentId
+          };
+          return Fliplet.Hooks.run('flListDataAfterUpdateComment', options)
+            .then(function () {
+              newCommentData = options.newCommentData;
+              _this.replaceComment(commentId, newCommentData, 'final');
+              options.commentContainer = _this.$container.find('.fl-individual-comment[data-id="' + newCommentData.id + '"]');
+              Fliplet.Hooks.run('flListDataAfterUpdateCommentShown', options);
+            });
+        });
     })
-    .then(function() {
-      _this.replaceComment(commentId, commentData, 'final');
+    .catch(function (error) {
+      _this.replaceComment(commentId, oldCommentData, 'final');
+      Fliplet.UI.Toast.error(error, {
+        message: 'Error updating comment'
+      });
     });
 }

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2195,7 +2195,8 @@ DynamicList.prototype.showComments = function(id, commentId) {
     });
   }).then(function() {
     // Get comments for entry
-    var entryComments = _.get(_.find(_this.listItems, { id: id }), 'comments');
+    var entry = _.find(_this.listItems, { id: id });
+    var entryComments = _.get(entry, 'comments');
 
     // Display comments
     entryComments.forEach(function(entry, index) {
@@ -2257,10 +2258,14 @@ DynamicList.prototype.showComments = function(id, commentId) {
     var hookData = {
       instance: _this,
       config: _this.data,
+      id: _this.data.id,
+      uuid: _this.data.uuid,
+      container: _this.$container,
       html: commentsHTML,
       src: commentsTemplate,
       comments: entryComments,
-      entryId: id
+      entryId: id,
+      record: entry
     };
 
     return Fliplet.Hooks.run('flListDataBeforeShowComments', hookData).then(function () {
@@ -2268,9 +2273,13 @@ DynamicList.prototype.showComments = function(id, commentId) {
       return Fliplet.Hooks.run('flListDataAfterShowComments', {
         instance: _this,
         config: _this.data,
+        id: _this.data.id,
+        uuid: _this.data.uuid,
+        container: _this.$container,
         html: commentsHTML,
         comments: entryComments,
-        entryId: id
+        entryId: id,
+        record: entry
       }).then(function () {
         var scrollTop = $commentArea[0].scrollHeight;
 
@@ -2332,6 +2341,7 @@ DynamicList.prototype.sendComment = function(id, value) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: record,
     comment: value,
     commentGuid: guid
   };
@@ -2419,6 +2429,7 @@ DynamicList.prototype.sendComment = function(id, value) {
           id: _this.data.id,
           uuid: _this.data.uuid,
           container: _this.$container,
+          record: record,
           commentEntry: comment,
           commentGuid: guid
         };
@@ -2550,6 +2561,7 @@ DynamicList.prototype.deleteComment = function(id) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: entry,
     commentId: id,
     commentContainer: commentHolder
   };
@@ -2594,9 +2606,9 @@ DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
     id: _this.data.id,
     uuid: _this.data.uuid,
     container: _this.$container,
+    record: entry,
     oldCommentData: oldCommentData,
-    newComment: newComment,
-    commentId: commentId
+    newComment: newComment
   };
 
   return Fliplet.Hooks.run('flListDataBeforeUpdateComment', options)
@@ -2625,9 +2637,9 @@ DynamicList.prototype.saveComment = function(entryId, commentId, newComment) {
             id: _this.data.id,
             uuid: _this.data.uuid,
             container: _this.$container,
+            record: entry,
             oldCommentData: oldCommentData,
-            newCommentData: newCommentData,
-            commentId: commentId
+            newCommentData: newCommentData
           };
           return Fliplet.Hooks.run('flListDataAfterUpdateComment', options)
             .then(function () {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -26,7 +26,7 @@ function DynamicList(id, data, container) {
   // Global variables
   this.allowClick = true;
   this.allUsers;
-  this.usersToMention = [];
+  this.usersToMention;
   this.commentsLoadingHTML = '<div class="loading-holder"><i class="fa fa-circle-o-notch fa-spin"></i> Loading...</div>';
   this.entryClicked = undefined;
   this.isFiltering;
@@ -412,9 +412,6 @@ DynamicList.prototype.attachObservers = function() {
       }
       _this.entryClicked = identifier;
       _this.showComments(identifier);
-      $('body').addClass('lock');
-      _this.$container.find('.simple-list-detail-overlay-content-holder').addClass('lock');
-      _this.$container.find('.simple-list-comment-panel').addClass('open');
 
       Fliplet.Analytics.trackEvent({
         category: 'list_dynamic_' + _this.data.layout,
@@ -909,6 +906,10 @@ DynamicList.prototype.checkIsToOpen = function() {
 
   _this.showDetails(entry.id, modifiedData).then(function () {
     _this.openedEntryOnQuery = true;
+
+    if (_this.pvOpenQuery.openComments || _this.pvOpenQuery.commentId) {
+      _this.showComments(entry.id, _this.pvOpenQuery.commentId);
+    }
   });
 }
 
@@ -1846,6 +1847,10 @@ DynamicList.prototype.getCommentUsers = function () {
     return Promise.resolve();
   }
 
+  if (this.usersToMention) {
+    return Promise.resolve(this.usersToMention);
+  }
+
   var _this = this;
 
   // Get users info for comments
@@ -2163,10 +2168,25 @@ DynamicList.prototype.updateCommentCounter = function(options) {
   _this.$container.find('.simple-list-comemnt-holder-' + id).html(html);
 }
 
-DynamicList.prototype.showComments = function(id) {
+DynamicList.prototype.showComments = function(id, commentId) {
   var _this = this;
 
   _this.$container.find('simple-list-comment-area').html(_this.commentsLoadingHTML);
+  $('body').addClass('lock');
+  _this.$container.find('.simple-list-detail-overlay-content-holder').addClass('lock');
+  _this.$container.find('.simple-list-comment-panel').addClass('open');
+
+  var context = {
+    dynamicListOpenId: id
+  };
+
+  if (commentId) {
+    context.dynamicListCommentId = commentId;
+  } else {
+    context.dynamicListOpenComments = 'true';
+  }
+
+  Fliplet.Page.Context.update(context);
 
   return _this.getCommentUsers().then(function () {
     return _this.getEntryComments({
@@ -2252,9 +2272,17 @@ DynamicList.prototype.showComments = function(id) {
         comments: entryComments,
         entryId: id
       }).then(function () {
-        $commentArea.stop().animate({
-          scrollTop: $commentArea[0].scrollHeight
-        }, 250);
+        var scrollTop = $commentArea[0].scrollHeight;
+
+        if (commentId) {
+          var $commentHolder = $('.fl-individual-comment[data-id="' + commentId + '"]');
+
+          if ($commentHolder.length) {
+            scrollTop = $commentHolder.position().top - $('.simple-list-comment-panel-header').outerHeight();
+          }
+        }
+
+        $commentArea.scrollTop(scrollTop);
       });
     });
   }).catch(function (error) {

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -1,7 +1,10 @@
 /**
- * this basically gets data out of the url as an INPUT,
+ * This gets data out of the URL as an INPUT,
  * parses it, and as an OUTPUT sets all the required variables used by LFD
  * for prepopulating, prefiltering and opening an entry
+ *
+ * Note: Boolean flags are treated as strings as Fliplet.Navigate.query
+ * does not parse the values into boolean values.
  */
 Fliplet.Registry.set('dynamicListQueryParser', function() {
   var _this = this;

--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -86,7 +86,9 @@ Fliplet.Registry.set('dynamicListQueryParser', function() {
   this.pvOpenQuery = _.pickBy({
     id: parseInt(Fliplet.Navigate.query['dynamicListOpenId'], 10),
     column: Fliplet.Navigate.query['dynamicListOpenColumn'],
-    value: Fliplet.Navigate.query['dynamicListOpenValue']
+    value: Fliplet.Navigate.query['dynamicListOpenValue'],
+    openComments: (Fliplet.Navigate.query['dynamicListOpenComments'] || '').toLowerCase() === 'true',
+    commentId: parseInt(Fliplet.Navigate.query['dynamicListCommentId'], 10)
   });
   this.queryOpen = _(this.pvOpenQuery).size() > 0;
   this.pvOpenQuery = this.queryOpen ? this.pvOpenQuery : null;


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4816

8 hooks related to comments have been added.

- `flListDataBeforeNewComment`
- `flListDataAfterNewComment`
- `flListDataAfterNewCommentShown`
- `flListDataBeforeUpdateComment`
- `flListDataAfterUpdateComment`
- `flListDataAfterUpdateCommentShown`
- `flListDataBeforeDeleteComment`
- `flListDataAfterDeleteComment`

2 query parameters are also added in relation to comments.

- **dynamicListOpenComments** (`true|false`) Open the comments view, if applicable (Default: `false`)
- **dynamicListCommentId** Open the comments view and scroll to the provided comment based on the comment ID
