### PR TITLE
Start tracking data source and entry IDs in comments

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2103,6 +2103,7 @@ DynamicList.prototype.getCommentIdentifier = function (record) {
   };
   var customIdentifier = Promise.resolve();
 
+  /* Deprecated method of defining comment identifiers */
   if (typeof this.data.getCommentIdentifier === 'function') {
     customIdentifier = this.data.getCommentIdentifier({
       record: record,

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2457,6 +2457,8 @@ DynamicList.prototype.sendComment = function(id, value) {
 
     comment.text = value;
     comment.timestamp = timestamp;
+    comment.contentDataSourceId = _this.data.dataSourceId;
+    comment.contentDataSourceEntryId = id;
 
     return _this.getCommentIdentifier(record)
       .then(function (identifier) {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2057,6 +2057,7 @@ DynamicList.prototype.getCommentIdentifier = function (record) {
   };
   var customIdentifier = Promise.resolve();
 
+  /* Deprecated method of defining comment identifiers */
   if (typeof this.data.getCommentIdentifier === 'function') {
     customIdentifier = this.data.getCommentIdentifier({
       record: record,

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2412,6 +2412,8 @@ DynamicList.prototype.sendComment = function(id, value) {
 
     comment.text = value;
     comment.timestamp = timestamp;
+    comment.contentDataSourceId = _this.data.dataSourceId;
+    comment.contentDataSourceEntryId = id;
 
     return _this.getCommentIdentifier(record)
       .then(function (identifier) {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6165

Adds data source ID and data source entry ID into comment settings for metadata processing.

`settings` is not used for identifying and retrieving comments, which means no functionality should be affected.