### PR TITLE
Show filters when bookmarks are selected

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1424,7 +1424,7 @@ DynamicList.prototype.getActiveFilters = function () {
 
 DynamicList.prototype.calculateFiltersHeight = function(hideFilters) {
   var _this = this;
-  var totalHeight = hideFilters || $('.toggle-agenda.mixitup-control-active, .toggle-bookmarks.mixitup-control-active').length
+  var totalHeight = hideFilters
     ? 0
     : this.$container.find('.hidden-filter-controls-content').height();
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5868

## Description
Show filters when bookmarks are selected

## Screenshots/screencasts
https://share.getcloudapp.com/p9u7Rvy2

## Backward compatibility

This change is fully backward compatible.

## Notes
While I tested this solution no other bugs were noticed.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 