### PR TITLE
Search container looks correct on IE

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1605,6 +1605,12 @@
     position: relative;
     top: 0 !important;
   }
+
+  .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {
+    margin: 10px 10px 0 10px;
+    left: auto;
+    right: auto;
+  }
 }
 
 /* Safari layout */


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5710#issuecomment-611412999
Tony's comment in this issue.

## Description
Correct CSS to look correctly on IE.

## Screenshots/screencasts
![ie-search](https://user-images.githubusercontent.com/52824207/79005552-c5458a80-7b5f-11ea-9778-926884b1caf7.PNG)

## Backward compatibility
This change is fully backward compatible.