### PR TITLE
Agenda search wrapper now looks correctly on IE on tablet and desktop

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1600,10 +1600,18 @@
     padding: 6px 12px;
   }
 
+  .fl-with-top-menu .new-agenda-list-container {
+    width: 100%;
+  }
+
   .fl-with-top-menu .new-agenda-list-container .agenda-date-selector,
   .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {
     position: relative;
     top: 0 !important;
+  }
+
+  .fl-with-top-menu .new-agenda-list-container .agenda-date-selector {
+      width: 100vw;
   }
 
   .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {

--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1607,7 +1607,8 @@
   }
 
   .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {
-    margin: 10px 10px 0 10px;
+    margin-top: 10px;
+    padding: 0 10px;
     left: auto;
     right: auto;
   }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5710

## Description
Somehow adding horizontal margin broke layout. Replaced with padding.

## Screenshots/screencasts
https://streamable.com/qkyo3f

## Backward compatibility
This change is fully backward compatible.