### PR TITLE
IE agenda looks correct on all menu types

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1600,21 +1600,21 @@
     padding: 6px 12px;
   }
 
-  .fl-with-top-menu .new-agenda-list-container {
+  .new-agenda-list-container {
     width: 100%;
   }
 
-  .fl-with-top-menu .new-agenda-list-container .agenda-date-selector,
-  .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {
+  .new-agenda-list-container .agenda-date-selector,
+  .new-agenda-list-container .section-top-wrapper {
     position: relative;
     top: 0 !important;
   }
 
-  .fl-with-top-menu .new-agenda-list-container .agenda-date-selector {
+  .new-agenda-list-container .agenda-date-selector {
       width: 100vw;
   }
 
-  .fl-with-top-menu .new-agenda-list-container .section-top-wrapper {
+  .new-agenda-list-container .section-top-wrapper {
     margin-top: 10px;
     padding: 0 10px;
     left: auto;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5710#issuecomment-611412999

## Description
I have not realized that .fl-with-top-menu affects only default menu. This way it should work as expected. I tested with all menus.

## Screenshots/screencasts
![ie-menus](https://user-images.githubusercontent.com/52824207/79451569-6b294700-7fef-11ea-9c7f-c8ae728d0e6d.PNG)


## Backward compatibility
This change is fully backward compatible.