### PR TITLE
Don't parse queries in edit mode

### DIFF
--- a/js/query-parser.js
+++ b/js/query-parser.js
@@ -9,6 +9,11 @@
 Fliplet.Registry.set('dynamicListQueryParser', function() {
   var _this = this;
 
+  if (Fliplet.Env.get('mode') === 'interact') {
+    // Don't parse queries when editing in Studio
+    return false;
+  }
+
   function splitQueryValues(input) {
     var testPattern = /^(?:\[[\w\W]*\])$/;
 


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6237

Query parameters are kept when user goes from Preview mode to Edit mode in Studio. This prevents the queries from being parsed and used as the component should remain in neutral of the queries in edit mode.