### PR TITLE
Bottom icon bar menu now is hidden when opening search/filter overlay

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -521,6 +521,14 @@
   margin-bottom: 20px;
 }
 
+.has-filter-overlay .new-news-feed-list-container {
+  /* Cover circle menu toggle and bottom menu bar when filter overlay is active  */
+  z-index: 1010;
+  -webkit-transition-delay: 0s;
+  -ms-transition-delay: 0s;
+  transition-delay: 0s;
+}
+
 @media screen and (min-width: 640px) {
   .news-feed-back-button {
     display: inline-block;

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -516,6 +516,14 @@
   margin-bottom: 20px;
 }
 
+.has-filter-overlay .simple-list-search-filter-overlay  {
+  /* Cover circle menu toggle and bottom menu bar when filter overlay is active  */
+  z-index: 1010;
+  -webkit-transition-delay: 0s;
+  -ms-transition-delay: 0s;
+  transition-delay: 0s;
+}
+
 @media screen and (min-width: 640px) {
   .simple-list-back-button {
     display: inline-block;

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -580,8 +580,9 @@
 
 /* List */
 .new-small-card-list-container {
-  max-width: 600px;
   margin: 0 auto;
+  max-width: 600px;
+  position: relative;
 }
 
 .new-small-card-list-container .small-card-list-wrapper {
@@ -747,6 +748,14 @@
   left: 0;
   padding: 15px;
   font-size: 25px;
+}
+
+.has-filter-overlay .new-small-card-list-container {
+  /* Cover circle menu toggle and bottom menu bar when filter overlay is active  */
+  z-index: 1010;
+  -webkit-transition-delay: 0s;
+  -ms-transition-delay: 0s;
+  transition-delay: 0s;
 }
 
 @media screen and (min-width: 640px) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -110,7 +110,7 @@ DynamicList.prototype.clearFilters = function () {
 
 DynamicList.prototype.hideFilterOverlay = function () {
   this.$container.find('.news-feed-search-filter-overlay').removeClass('display');
-  $('body').removeClass('lock');
+  $('body').removeClass('lock has-filter-overlay');
 };
 
 DynamicList.prototype.attachObservers = function() {
@@ -286,7 +286,7 @@ DynamicList.prototype.attachObservers = function() {
 
       if (_this.data.filtersInOverlay) {
         $parentElement.find('.news-feed-search-filter-overlay').addClass('display');
-        $('body').addClass('lock');
+        $('body').addClass('lock has-filter-overlay');
 
         Fliplet.Analytics.trackEvent({
           category: 'list_dynamic_' + _this.data.layout,
@@ -310,7 +310,7 @@ DynamicList.prototype.attachObservers = function() {
       var $elementClicked = $(this);
       var $parentElement = $elementClicked.parents('.news-feed-search-filter-overlay');
       $parentElement.removeClass('display');
-      $('body').removeClass('lock');
+      $('body').removeClass('lock has-filter-overlay');
 
       // Clear all selected filters
       _this.toggleFilterElement(_this.$container.find('.mixitup-control-active:not(.toggle-bookmarks)'), false);

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -104,7 +104,7 @@ DynamicList.prototype.clearFilters = function () {
 
 DynamicList.prototype.hideFilterOverlay = function () {
   this.$container.find('.simple-list-search-filter-overlay').removeClass('display');
-  $('body').removeClass('lock');
+  $('body').removeClass('lock has-filter-overlay');
 };
 
 DynamicList.prototype.attachObservers = function() {
@@ -262,7 +262,7 @@ DynamicList.prototype.attachObservers = function() {
 
       if (_this.data.filtersInOverlay) {
         $parentElement.find('.simple-list-search-filter-overlay').addClass('display');
-        $('body').addClass('lock');
+        $('body').addClass('lock has-filter-overlay');
 
         Fliplet.Analytics.trackEvent({
           category: 'list_dynamic_' + _this.data.layout,
@@ -286,7 +286,7 @@ DynamicList.prototype.attachObservers = function() {
       var $elementClicked = $(this);
       var $parentElement = $elementClicked.parents('.simple-list-search-filter-overlay');
       $parentElement.removeClass('display');
-      $('body').removeClass('lock');
+      $('body').removeClass('lock has-filter-overlay');
 
       // Clear all selected filters
       _this.toggleFilterElement(_this.$container.find('.mixitup-control-active:not(.toggle-bookmarks)'), false);

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -109,7 +109,7 @@ DynamicList.prototype.clearFilters = function () {
 
 DynamicList.prototype.hideFilterOverlay = function () {
   this.$container.find('.small-card-search-filter-overlay').removeClass('display');
-  $('body').removeClass('lock');
+  $('body').removeClass('lock has-filter-overlay');
 };
 
 DynamicList.prototype.attachObservers = function() {
@@ -332,7 +332,7 @@ DynamicList.prototype.attachObservers = function() {
 
       if (_this.data.filtersInOverlay) {
         $parentElement.find('.small-card-search-filter-overlay').addClass('display');
-        $('body').addClass('lock');
+        $('body').addClass('lock has-filter-overlay');
 
         Fliplet.Analytics.trackEvent({
           category: 'list_dynamic_' + _this.data.layout,
@@ -356,7 +356,7 @@ DynamicList.prototype.attachObservers = function() {
       var $elementClicked = $(this);
       var $parentElement = $elementClicked.parents('.small-card-search-filter-overlay');
       $parentElement.removeClass('display');
-      $('body').removeClass('lock');
+      $('body').removeClass('lock has-filter-overlay');
 
       // Clear all selected filters
       _this.toggleFilterElement(_this.$container.find('.mixitup-control-active:not(.toggle-bookmarks)'), false);


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6252

## Description
Similar logic is implemented in the agenda layout. 
When the user opens search/filter overlay, class "has-filter-overlay" is added to the body, and therefore z-index 1010 is applied (bottom-icon-bar-menu has 1009 z-index). When the user closes search/filter overlay using "back arrow" or by apply button,   class "has-filter-overlay"  is removed.

## Screenshots/screencasts
![bottom-icon-bar-fix](https://user-images.githubusercontent.com/52824207/79996675-636f1400-84c1-11ea-9af3-1c8509432ae3.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @YaroslavOvdii