### PR TITLE
[Fix] Let Fliplet.Navigate.url() determine if authentication is needed

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1278,7 +1278,6 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     }
 
     if (options.summaryLinkAction.type === 'url') {
-      value = Fliplet.Media.authenticate(value);
       Fliplet.Navigate.url(value);
     } else {
       var opt = { transition: 'fade' };


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6318

Since this JS API change https://github.com/Fliplet/fliplet-api/pull/4032 the `Fliplet.Navigate.url()` self-determines whether the URL needs to be authenticated. There's therefore no need for the LFD to authenticate if it's passing the URL to `Fliplet.Navigate.url()`.

However, perhaps the fix should lie in the `Fliplet.Media.authenticate()` function so that the function never authenticates unless it's a native app? i.e. adding these 3 lines:

![image](https://user-images.githubusercontent.com/290733/80695253-873be680-8acd-11ea-8d10-af1d896a0ae6.png)
