### PR TITLE
[Fix] Limit text now is hidden when user is searching or filtering

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1643,7 +1643,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1446,7 +1446,7 @@ DynamicList.prototype.renderLoopHTML = function () {
         // Changing close icon in the fa-times-thin class for windows 7 IE11
         if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
           $('.fa-times-thin').addClass('win7');
-        }        
+        }
 
         resolve(data);
       }
@@ -1643,7 +1643,9 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', truncated);
+        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
+        
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1643,9 +1643,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
-        
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1643,7 +1643,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1427,7 +1427,9 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', truncated);
+        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
+        
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1427,9 +1427,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
-        
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1427,7 +1427,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1427,7 +1427,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1279,7 +1279,9 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', truncated);
+        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
+        
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1279,9 +1279,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        var showLimitText = _this.isSearching || _this.isFiltering || _this.showBookmarks;
-        
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', showLimitText);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1279,7 +1279,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1279,7 +1279,7 @@ DynamicList.prototype.searchData = function(options) {
 
       if (limitEntriesEnabled) {
         // Do not show limit text when user is searching or filtering
-        _this.$container.find('.limit-entries-text').toggleClass('hidden', !!results.filteredResult);
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', results.filteredResult);
       }
 
       if (!_this.data.forceRenderList

--- a/js/utils.js
+++ b/js/utils.js
@@ -544,7 +544,8 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
 
     return Promise.resolve({
       records: searchResults,
-      truncated: truncated
+      truncated: truncated,
+      filteredResult: showBookmarks || !_.isEmpty(activeFilters) || value
     });
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -545,7 +545,7 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
     return Promise.resolve({
       records: searchResults,
       truncated: truncated,
-      filteredResult: showBookmarks || !_.isEmpty(activeFilters) || value
+      filteredResult: !!(showBookmarks || !_.isEmpty(activeFilters) || value)
     });
   }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6186

## Description
I remembered why I did not use "truncated" variable. We cannot use it because when we limit the number of searches truncated variable becomes true. Therefore is it always true when searches are limited.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko