### PR TITLE
Limit text now is hidden when user is searching or filtering

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1446,7 +1446,7 @@ DynamicList.prototype.renderLoopHTML = function () {
         // Changing close icon in the fa-times-thin class for windows 7 IE11
         if (/Windows NT 6.1/g.test(navigator.appVersion) && Modernizr.ie11) {
           $('.fa-times-thin').addClass('win7');
-        }        
+        }
 
         resolve(data);
       }
@@ -1642,7 +1642,10 @@ DynamicList.prototype.searchData = function(options) {
       }
 
       if (limitEntriesEnabled) {
-        _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
+        // Do not show limit text when user is searching or filtering
+        var hideLimitText = !results.truncated && _this.data.limitEntries > 0;
+
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', hideLimitText);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1426,7 +1426,10 @@ DynamicList.prototype.searchData = function(options) {
       }
 
       if (limitEntriesEnabled) {
-        _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
+        // Do not show limit text when user is searching or filtering
+        var hideLimitText = !results.truncated && _this.data.limitEntries > 0;
+
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', hideLimitText);
       }
 
       if (!_this.data.forceRenderList

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1278,7 +1278,10 @@ DynamicList.prototype.searchData = function(options) {
       }
 
       if (limitEntriesEnabled) {
-        _this.$container.find('.limit-entries-text')[truncated && _this.data.limitEntries > 0 ? 'removeClass' : 'addClass']('hidden');
+        // Do not show limit text when user is searching or filtering
+        var hideLimitText = !results.truncated && _this.data.limitEntries > 0;
+
+        _this.$container.find('.limit-entries-text').toggleClass('hidden', hideLimitText);
       }
 
       if (!_this.data.forceRenderList


### PR DESCRIPTION
@sofiiakvasnevska @tonytlwu 

## Issue
Fliplet/fliplet-studio#6186

## Description
Actually we can use the "truncated" variable. I was confused by it as it was reassigned in code and I did not see it. This way everything works as expected.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko