### PR TITLE
[Fix] The bookmark icon will be placed on the left as it should be.

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -1333,8 +1333,11 @@
   align-items: center;
 }
 
-.agenda-item-bookmark.more-buttons {
+.agenda-item-bookmark {
   display: flex;
+}
+
+.agenda-item-bookmark.more-buttons {
   padding: 15px 0;
   margin: 10px 0;
   border-top: 1px solid rgba(51, 51, 51, 0.1);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6223

## Description
The bookmark icon will be placed on the left as it should be.

## Screenshots/screencasts
https://share.getcloudapp.com/Apujmvnq

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This issue occurred after this [PR](https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/373)