### PR TITLE
[Fix] Show correct error message when the user doesn't have permissions to the Data Source.

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1040,10 +1040,6 @@ DynamicList.prototype.connectToDataSource = function() {
     }
 
     return getData(cache);
-  }).catch(function (error) {
-    Fliplet.UI.Toast.error(error, {
-      message: 'Error loading data'
-    });
   });
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6548

## Description
Show correct error message when the user doesn't have permissions to the Data Source.

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/84146951-3375d300-aa65-11ea-8af3-168482befb63.png)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Removed `.catch()` from `connectToDataSource()` function give controll over error handlers to the `initialize()` function.
It wouldn't have any effect on the current flow of the Agenda layout because the `connectToDataSource()` function used only with the `initialize()` function.