### PR TITLE
[Fix] Removed icon opacity for appearence settings to work correctly 

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -390,7 +390,6 @@
 
 .new-agenda-list-container .list-search-icon .fa {
   display: inline-block;
-  opacity: 0.3;
   font-size: 20px;
   width: 35px;
   height: 35px;

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -266,7 +266,6 @@
 
 .new-news-feed-list-container .list-search-icon .fa {
   display: inline-block;
-  opacity: 0.3;
   font-size: 20px;
   width: 35px;
   height: 35px;

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -268,7 +268,6 @@
 
 .simple-list-container .list-search-icon .fa {
   display: inline-block;
-  opacity: 0.3;
   font-size: 20px;
   width: 35px;
   height: 35px;

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -326,7 +326,6 @@
 
 .new-small-card-list-container .list-search-icon .fa {
   display: inline-block;
-  opacity: 0.3;
   font-size: 20px;
   width: 35px;
   height: 35px;


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#6225

## Description
As now we set icon opacity thought rgba we do not need extra opacity property.

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko