### PR TITLE
[Fix] LFD widget is now aligned on all screens.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -197,3 +197,7 @@
   padding-top: 2px;
   padding-bottom: 2px;
 }
+
+[data-widget-package="com.fliplet.dynamic-lists"] {
+  width: 100%;
+}


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6620

## Description
LFD widget is now aligned on all screens

## Screenshots/screencasts
https://share.getcloudapp.com/8Lu7bkZj

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko