### PR TITLE
[Fix] Allow users to swipe agenda dates.

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -2173,7 +2173,7 @@ DynamicList.prototype.bindTouchEvents = function() {
 
     _this.isPanning = true;
     _this.sliderCount = _this.$container.find('.agenda-list-day-holder').length;
-    _this.activeSlideIndex = _this.$container.find('.agenda-list-day-holder').index('.agenda-list-day-holder.active');
+    _this.activeSlideIndex = _this.$container.find('.agenda-list-day-holder').index(_this.$container.find('.agenda-list-day-holder.active'));
     _this.$container.find('.agenda-date-selector, .agenda-date-selector ul').addClass('is-panning');
     _this.scrollValue = -1 * e.deltaX;
     _this.$container.find('.agenda-cards-wrapper').scrollLeft(_this.copyOfScrollValue + _this.scrollValue);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6763

## Description
Allow users to swipe agenda dates.

## Screenshots/screencasts
https://share.getcloudapp.com/5zuXq1bX

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
The issue was that the active slide index wasn't searched correctly.
For testing used the Android 9.0 simulator.