### PR TITLE
[Maintenance] Ensures date format doesn't change when date locales become available

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -18,6 +18,9 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
   var computedFieldClashes = [];
   var div = document.createElement('DIV');
 
+  // Keep date format in English until localisation is correctly rollded out
+  moment.locale('en');
+
   function isValidImageUrl(str) {
     return Static.RegExp.httpUrl.test(str)
       || Static.RegExp.base64Image.test(str)


### PR DESCRIPTION
Keep date format as `en` until localisation is properly rolled out

Required for https://github.com/Fliplet/fliplet-api/pull/4149