### PR TITLE
[Fix] Line clamp text in IE 11 by setting max-height without using elllpses

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -800,6 +800,7 @@
 
 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description {
   overflow: hidden;
+  max-height: 4.5em;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -809,7 +810,6 @@
 }
 
 html.ie11 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description {
-  max-height: 4.2em;
 }
 
 .new-news-feed-list-container .slide-over .news-feed-item-inner-content .news-feed-item-description,

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -810,6 +810,17 @@
 }
 
 html.ie11 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description {
+  display: block;
+  max-height: 1.5em;
+}
+
+html.ie11 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description:before {
+  content: "\f138";
+  font-family: FontAwesome;
+  display: inline-block;
+  float: right;
+  padding-left: 1px;
+  padding-right: 1px;
 }
 
 .new-news-feed-list-container .slide-over .news-feed-item-inner-content .news-feed-item-description,

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -803,10 +803,13 @@
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  height: 4.4em;
   word-wrap: break-word;
   overflow-wrap: break-word;
   word-break: break-word;
+}
+
+html.ie11 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-over .news-feed-item-inner-content .news-feed-item-description {
+  max-height: 4.2em;
 }
 
 .new-news-feed-list-container .slide-over .news-feed-item-inner-content .news-feed-item-description,

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -585,7 +585,7 @@
 }
 
 html.ie11 .simple-list-item .list-item-description {
-  max-height: 4.2em;
+  max-height: 4.5em;
 }
 
 .simple-list-item .list-item-title {

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -584,6 +584,10 @@
   word-break: break-word;
 }
 
+html.ie11 .simple-list-item .list-item-description {
+  max-height: 4.2em;
+}
+
 .simple-list-item .list-item-title {
   font-size: 18px;
 }

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1446,15 +1446,6 @@ DynamicList.prototype.renderLoopHTML = function () {
         $('#news-feed-list-wrapper-' + _this.data.id).append(template(nextBatch));
         renderLoopIndex++;
 
-        if (Modernizr.ie11) {
-          // In case if there is no data-line-clamp attribute we should clamp .news-feed-item-description selector with 3 lines
-          var $lineClamp = $('[data-line-clamp]');
-          var selector = $lineClamp.length ? '[data-line-clamp]' : '.news-feed-item-description';
-          var linesToClamp = $lineClamp.length ? $lineClamp.data('line-clamp') : 3;
-
-          window.ellipsed.ellipsis(selector, linesToClamp, { delimiter: '' });
-        }
-
         // if the browser is ready, render
         requestAnimationFrame(render);
       } else {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -1243,15 +1243,6 @@ DynamicList.prototype.renderLoopHTML = function () {
         $('#simple-list-wrapper-' + _this.data.id).append(template(nextBatch));
         renderLoopIndex++;
 
-        if (Modernizr.ie11) {
-          // In case if there is no data-line-clamp attribute we should clamp .list-item-description selector with 3 lines
-          var $lineClamp = $('[data-line-clamp]');
-          var selector = $lineClamp.length ? '[data-line-clamp]' : '.list-item-description';
-          var linesToClamp = $lineClamp.length ? $lineClamp.data('line-clamp') : 3;
-
-          window.ellipsed.ellipsis(selector, linesToClamp, { delimiter: '' });
-        }
-
         // if the browser is ready, render
         requestAnimationFrame(render);
       } else{


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6899

<img src="https://user-images.githubusercontent.com/290733/89789764-f2f40d80-db18-11ea-8530-6ef98644a475.png" width="49%" /> <img src="https://user-images.githubusercontent.com/290733/89789834-0acb9180-db19-11ea-936b-2405ccd64b1b.png" width="49%" />
