### PR TITLE
[Fix] Users will see filters text in overlay mode

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -125,6 +125,10 @@
   width: 40%;
 }
 
+.filter-holder .panel-group .panel .panel-body {
+  background-color: transparent;
+}
+
 /*
   This part of the code is needed for supporting .fa-times-thin class in users who updated
   to use UNICODE icons instead of SVG icons.


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6858

## Description
Users will see filters text in overlay mode

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/90010101-ef42c100-dca7-11ea-8da8-9fe8ee7143ee.png)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko