### PR TITLE
[Fix] Filters won't go over the screen.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -125,6 +125,10 @@
   width: 40%;
 }
 
+.hidden-filter-controls {
+  max-width: 100%;
+}
+
 /*
   This part of the code is needed for supporting .fa-times-thin class in users who updated
   to use UNICODE icons instead of SVG icons.


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6859

## Description
Filters won't go over the screen.

## Screenshots/screencasts
https://share.getcloudapp.com/2Nuy59O1

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko