### PR TITLE
[Fix] Old alert appears when interacting with comments in LFD

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -639,26 +639,26 @@ DynamicList.prototype.attachObservers = function() {
             },
             {
               label: 'Delete',
-              action: function (i) {
+              action: function () {
                 var options = {
                   title: 'Delete comment',
                   message: 'Are you sure you want to delete this comment?',
-                  labels: ['Delete','Cancel'] // Native only (defaults to [OK,Cancel])
-                };
-
-                Fliplet.Navigate.confirm(options)
-                  .then(function(result) {
-                    Fliplet.Analytics.trackEvent({
-                      category: 'list_dynamic_' + _this.data.layout,
-                      action: 'comment_delete'
-                    });
-
-                    if (!result) {
-                      return;
+                  labels: [
+                    {
+                      label: 'Delete',
+                      action: function(i) {
+                        Fliplet.Analytics.trackEvent({
+                          category: 'list_dynamic_' + _this.data.layout,
+                          action: 'comment_delete'
+                        });
+    
+                        _this.deleteComment(commentId);
+                      }
                     }
-
-                    _this.deleteComment(commentId);
-                  });
+                  ]
+                };
+                
+                Fliplet.UI.Actions(options);
               }
             }
           ],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
-  "name": "List (from data source)",
-  "package": "com.fliplet.dynamic-lists",
+  "name": "List (from data source)-andrey",
+  "package": "com.fliplet.dynamic-lists-andrey",
   "version": "1.4.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:list"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
-  "name": "List (from data source)-andrey",
-  "package": "com.fliplet.dynamic-lists-andrey",
+  "name": "List (from data source)",
+  "package": "com.fliplet.dynamic-lists",
   "version": "1.4.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:list"],


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/jira/software/projects/OD/issues/OD-60?filter=myopenissues

## Description
Removed old alert from comment deletion

## Screenshots/screencasts

![Снимок экрана 2020-09-15 в 16 51 00](https://user-images.githubusercontent.com/71251809/93220942-d5e4d700-f775-11ea-83da-ad7f7007f188.png)

![Снимок экрана 2020-09-15 в 16 51 25](https://user-images.githubusercontent.com/71251809/93220907-c9607e80-f775-11ea-9049-baeb14c95a07.png)


## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko