### PR TITLE
ID-327 [Fix] Fixes an issue where filters couldn't be selected using only query values

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -236,24 +236,28 @@ Fliplet.Registry.set('dynamicListUtils', (function () {
       return [];
     }
 
-    var selectors = [];
-
     if (!Array.isArray(query.value)) {
       query.value = [query.value];
     }
 
-    if (_.get(query, 'column', []).length) {
-      // Select filters using on legacy column-specific methods
-      query.column.forEach(function (field, index) {
-        if (!Array.isArray(query.value[index])) {
-          query.value[index] = [query.value[index]];
-        }
-
-        query.value[index].forEach(function (value) {
-          selectors.push('[data-field="' + field + '"][data-value="' + value + '"]');
-        });
+   if (!_.get(query, 'column', []).length) {
+      return _.map(_.flatten(query.value), function (value) {
+        return '[data-value="' + value + '"]';
       });
     }
+
+    var selectors = [];
+
+     // Select filters using column-specific methods
+    query.column.forEach(function (field, index) {
+      if (!Array.isArray(query.value[index])) {
+        query.value[index] = [query.value[index]];
+      }
+
+      query.value[index].forEach(function (value) {
+        selectors.push('[data-field="' + field + '"][data-value="' + value + '"]');
+      });
+    });
 
     return selectors;
   }


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-327

Users used to be able to set a filter query by merely specifying `dynamicListFilterValue`, but that was broken when https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/430 was implemented. This capability has been added back with a more reliable implementation to avoid https://weboo.atlassian.net/browse/ID-29 from happening again.