### PR TITLE
OD-313 [Fix] Fix sorting for numbers (null and zero)

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1098,11 +1098,11 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
 
           return 0;
         case 'number':
-          if (+aValue !== 0 && !parseFloat(aValue, 10)) {
+          if (!parseFloat(aValue, 10) && parseFloat(aValue, 10) !== 0) {
             return isSortAsc ? 1 : -1;
           }
 
-          if (+bValue !== 0 && !parseFloat(bValue, 10)) {
+          if (!parseFloat(bValue, 10) && parseFloat(bValue, 10) !== 0) {
             return isSortAsc ? -1 : 1;
           }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -1098,12 +1098,12 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
 
           return 0;
         case 'number':
-          if (!parseFloat(aValue, 10) && parseFloat(aValue, 10) !== 0) {
-            return isSortAsc ? 1 : -1;
+          if (!parseFloat(aValue, 10) &&  parseFloat(aValue, 10) !== 0) {
+            return isSortAsc ? -1 : 1;
           }
 
           if (!parseFloat(bValue, 10) && parseFloat(bValue, 10) !== 0) {
-            return isSortAsc ? -1 : 1;
+            return isSortAsc ? 1 : -1;
           }
 
           if (isSortAsc) {


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-313 https://weboo.atlassian.net/browse/OD-313
## Description
There was a problem because `+undefined === NaN` but `+null === 0`
## Screenshots/screencasts
https://monosnap.com/file/uhyZBWYZZicxVXclkxzFj8WK1vrmOc
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz