### PR TITLE
[Maintenance] Remove helpers defined in the Fliplet Handlebars library

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -46,18 +46,6 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
   }
 
   function registerHandlebarsHelpers() {
-    Handlebars.registerHelper('plaintext', function(context) {
-      if (_.isFunction(_.get(context, 'toString'))) {
-        context = context.toString();
-      }
-
-      return $('<div></div>').html(context).text();
-    });
-
-    Handlebars.registerHelper('removeSpaces', function(context) {
-      return context.replace(/\s+/g, '');
-    });
-
     Handlebars.registerHelper('formatDate', function(date) {
       if (!date) {
         return;
@@ -72,37 +60,6 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       }
 
       return splitByCommas(context).join(', ');
-    });
-
-    Handlebars.registerHelper('ifCond', function(v1, operator, v2, options) {
-      switch (operator) {
-        case '==':
-          return (v1 == v2) // eslint-disable-line eqeqeq
-            ? options.fn(this)
-            : options.inverse(this);
-        case '===':
-          return (v1 === v2) ? options.fn(this) : options.inverse(this);
-        case '!=':
-          return (v1 != v2) // eslint-disable-line eqeqeq
-            ? options.fn(this)
-            : options.inverse(this);
-        case '!==':
-          return (v1 !== v2) ? options.fn(this) : options.inverse(this);
-        case '<':
-          return (v1 < v2) ? options.fn(this) : options.inverse(this);
-        case '<=':
-          return (v1 <= v2) ? options.fn(this) : options.inverse(this);
-        case '>':
-          return (v1 > v2) ? options.fn(this) : options.inverse(this);
-        case '>=':
-          return (v1 >= v2) ? options.fn(this) : options.inverse(this);
-        case '&&':
-          return (v1 && v2) ? options.fn(this) : options.inverse(this);
-        case '||':
-          return (v1 || v2) ? options.fn(this) : options.inverse(this);
-        default:
-          return options.inverse(this);
-      }
     });
 
     Handlebars.registerHelper('validateImage', validateImageUrl);


### PR DESCRIPTION
The following Handlebars helpers are removed as they will be [implemented via Fliplet's Handlebars library](https://github.com/Fliplet/fliplet-api/pull/4489), which must be deployed before the widget is deployed.

* `ifCond`
* `plaintext`
* `removeSpaces`