### PR TITLE
OD-457 [Fix] Show agenda cards after filter overlay hiding

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -127,6 +127,7 @@ DynamicList.prototype.clearFilters = function() {
 
 DynamicList.prototype.hideFilterOverlay = function() {
   this.$container.find('.new-agenda-search-filter-overlay').removeClass('display');
+  this.$container.find('.section-top-wrapper, .agenda-cards-wrapper, .dynamic-list-add-item').removeClass('hidden');
   $('body').removeClass('lock has-filter-overlay');
 };
 


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-457 https://weboo.atlassian.net/browse/OD-457
## Description
Show agenda cards after filter overlay hiding
## Screenshots/screencasts
https://monosnap.com/file/kZcO5e7Hya75p4UVJT649tFHkGOTHl
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii