### PR TITLE
OD-457 [Fix] Show agenda cards after filter overlay hiding and after forward/backward animation

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -127,6 +127,7 @@ DynamicList.prototype.clearFilters = function() {
 
 DynamicList.prototype.hideFilterOverlay = function() {
   this.$container.find('.new-agenda-search-filter-overlay').removeClass('display');
+  this.$container.find('.section-top-wrapper, .agenda-cards-wrapper, .dynamic-list-add-item').removeClass('hidden');
   $('body').removeClass('lock has-filter-overlay');
 };
 

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1821,6 +1821,7 @@ DynamicList.prototype.moveForwardDate = function(index, difference) {
   ]).then(function() {
     _this.isPanning = false;
     _this.animatingForward = false;
+    _this.$container.find('.agenda-list-day-holder.active').removeClass('hidden');
   });
 };
 
@@ -1855,6 +1856,7 @@ DynamicList.prototype.moveBackDate = function(index, difference) {
   ]).then(function() {
     _this.isPanning = false;
     _this.animatingBack = false;
+    _this.$container.find('.agenda-list-day-holder.active').removeClass('hidden');
   });
 };
 


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-457 https://weboo.atlassian.net/browse/OD-457
## Description
Show agenda cards after filter overlay hiding and after forward/backward animations
## Screenshots/screencasts
Overlay: https://monosnap.com/file/kZcO5e7Hya75p4UVJT649tFHkGOTHl
Animations: https://monosnap.com/file/m8wTwQFxppAHslVPhoVnsYr2ybOtwA
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii