### PR TITLE
OD-497 [Fix] Make comments overlay closable in simple list

### DIFF
--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -588,7 +588,7 @@ DynamicList.prototype.attachObservers = function() {
         action: 'comments_open'
       });
     })
-    .on('click keydown', '.simple-list-comment-close-panel', function() {
+    .on('click keydown', '.simple-list-comment-close-panel', function(event) {
       if (!_this.Utils.accessibilityHelpers.isExecute(event)) {
         return;
       }


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-497 https://weboo.atlassian.net/browse/OD-497
## Description
Made comments overlay closeable in simle list LFD by fixing accessibility issue (no `event` parameter provided)
## Screenshots/screencasts
https://monosnap.com/file/OZrffKG0JzomX24qN5dTURTiJT7bsK
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz 