### PR TITLE
ID-1150 [Fix] Ensure date selectors are correctly highlighted

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -1740,18 +1740,28 @@ DynamicList.prototype.initializeSocials = function(records) {
 
 /* ANIMATION FOR DATES BACK AND FORWARD */
 // animates dates forward
-DynamicList.prototype.animateDateForward = function(nextDateElement, nextDateElementWidth) {
+DynamicList.prototype.animateDateForward = function($nextDateElement, nextDateElementWidth) {
   var _this = this;
 
   return new Promise(function(resolve) {
+    var $currentActiveDate = _this.$container.find('.agenda-date-selector li.active');
+
+    $currentActiveDate.removeClass('active').find('.day').addBack().css('color', '#000');
+    setTimeout(function() {
+      $currentActiveDate.find('.day').addBack().css('color', '');
+
+      $nextDateElement.addClass('active').find('.day').addBack().css('color', '#000');
+      setTimeout(function() {
+        $nextDateElement.find('.day').addBack().css('color', '');
+      }, 0);
+    }, 0);
+
     _this.$container.find('.agenda-date-selector ul').animate({
       scrollLeft: '+=' + nextDateElementWidth
     },
     _this.ANIMATION_SPEED,
     'swing',  // animation easing
     function() {
-      _this.$container.find('.agenda-date-selector li.active').removeClass('active');
-      nextDateElement.addClass('active');
       resolve();
     });
   });
@@ -1780,18 +1790,28 @@ DynamicList.prototype.animateAgendaForward = function(nextAgendaElement, nextAge
 };
 
 // animates dates back
-DynamicList.prototype.animateDateBack = function(prevDateElement, prevDateElementWidth) {
+DynamicList.prototype.animateDateBack = function($prevDateElement, prevDateElementWidth) {
   var _this = this;
 
   return new Promise(function(resolve) {
+    var $currentActiveDate = _this.$container.find('.agenda-date-selector li.active');
+
+    $currentActiveDate.removeClass('active').find('.day').addBack().css('color', '#000');
+    setTimeout(function() {
+      $currentActiveDate.find('.day').addBack().css('color', '');
+
+      $prevDateElement.addClass('active').find('.day').addBack().css('color', '#000');
+      setTimeout(function() {
+        $prevDateElement.find('.day').addBack().css('color', '');
+      }, 0);
+    }, 0);
+
     _this.$container.find('.agenda-date-selector ul').animate({
       scrollLeft: '-=' + prevDateElementWidth
     },
     _this.ANIMATION_SPEED,
     'swing',  // animation easing
     function() {
-      _this.$container.find('.agenda-date-selector li.active').removeClass('active');
-      prevDateElement.addClass('active');
       resolve();
     });
   });
@@ -2505,6 +2525,7 @@ DynamicList.prototype.addDetailViewData = function(entry) {
 
   if (_.isArray(entry.entryDetails) && entry.entryDetails.length) {
     _this.Utils.Record.assignImageContent(_this, entry);
+
     return entry;
   }
 


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1150

Possibly due to the number of date selectors, the rendering engine is unable to render the update styles based on the new classes.

This forces re-render by applying and removing CSS styles.