### PR TITLE
ID-1525 [Fix] Ensure search results are correct for strings with commas

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -828,7 +828,8 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
   }
 
   function removeSymbols(str) {
-    return ('' + str).replace(/[&\/\\#,+()$~%.`'‘’"“”:*?<>{}]+/g, '');
+    // Remove commonly used symbols in text that should be ignored for string matching
+    return ('' + str).replace(/[&\/\\#+()$~%.`'‘’"“”:*?<>{}]+/g, '');
   }
 
   function recordContains(record, value) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1525

This PR https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/159 introduced a list of symbols to be removed before search comparison is performed. The `,` character should be kept as it's commonly used for CSV strings.