### PR TITLE
ID-1587 [Fix] Avoid duplicate filters being rendered when queries are used

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1544,7 +1544,12 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       })
       .flatten()
       .uniqBy(function(filter) {
-        // _.uniqBy iteratee
+        // Ignore the filter class name when computing unique filter values
+        if (filter.data && filter.data.class) {
+          delete filter.data.class;
+        }
+
+        // _.uniqBy iteratee, ignoring classes
         return JSON.stringify(filter);
       })
       .orderBy(function(obj) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1587

When a query parameter is used, an additional temporary record is added for the purpose of computing filter values. However, not all filter values are created with a `class` property, which caused the temporary value be considered as a unique value from the standard class-less values.

The `class` property can be safely ignored for the purpose of computing filter values.