### PR TITLE
ID-1641 [Fix] Only apply SafeString if custom templates are used

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -168,7 +168,11 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
         break;
     }
 
-    return toFormattedString(new Handlebars.SafeString(content));
+    if (field.column === 'custom') {
+      content = new Handlebars.SafeString(content);
+    }
+
+    return toFormattedString(content);
   }
 
   /**


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1641

This brings the fix in https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/644 closer to the initial implementation in https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/149 while still allowing for number/date localisation.

Follows https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/636