### PR TITLE
ID-1750 [Fix] Check more extensively for image URL types

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -2743,9 +2743,14 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
     }));
   }
 
-  function getImagesUrlsByRegex(imageString) {
+  /**
+   * Assesses a string input and return it as an array if it's a valid image URL
+   * @param {String} str - String to be assessed
+   * @returns {Array|null} An array of a single image URL or null if input is not an image URL
+   */
+  function getImagesUrlsByRegex(str) {
     // Regex to detect if line contains URL
-    return imageString.match(/((?:ftp|http|https):\/\/(?:\w+:{0,1}\w*@)?(?:\S+)(?::[0-9]+)?(?:\/|\/(?:[\w#!:.?+=&%@!-/]))?)/g);
+    return isValidImageUrl(str) ? [str] : null;
   }
 
   function openLinkAction(options) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1750

The reported bug was caused by the `getImageUrlsByRegex()` function created in https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/562 checked the string for the `http://` prefix (and the alike). However, this does not include the other image URL types (`datasources/*`, Base64 URL etc.)

This PR changes the code to assess the other types of image URL.

The old code included an unintended feature where if the input included multiple image URLs in a string, e.g. `https://google.com, https://fliplet.com`, it was unable to return `['https://google.com', 'https://fliplet.com']`. There is no realistic scenario where this is useful so it shouldn't be a problem.