### PR TITLE
OD-483 [Fix] Fixed indentation of images in detailed view on tablet and web view for LFD entry

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -276,10 +276,6 @@
     width: calc(33.33% - 7.5px);
     margin-right: 15px;
   }
-
-  .multiple-images-item:nth-of-type(3n) {
-    margin-right: 0;
-  }
 }
 
 .file-holder {


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-483 https://weboo.atlassian.net/browse/OD-483

## Description
**Problem:** When the screen width is set to `min-width: 640px`, the margin is set to `margin-right: 0px`;
**Solution:** The given part has been removed and the indent on the right remains with the value `margin-right: 15px`.

## Screenshots/screencasts
https://storyxpress.co/video/kxq2ybvfrhsmqumd7

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko