### PR TITLE
ID-1789 [Fix] Only exclude null, undefined or false values from filters

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -673,16 +673,16 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
         var $el = $(el);
         var type = $el.data('type');
 
-        return _.pickBy({
+        return _.omitBy({
           field: el.dataset.field,
           type: type,
           value: $el.data(inputDataNames[type]).get()
-        });
+        }, _.isNil);
       })
       .groupBy('field')
       .mapValues(function(filters) {
         // Sort the values to assume the FROM value is not after the TO value
-        var values = _.compact(_.map(filters, 'value'));
+        var values = _.map(filters, 'value');
         var type = filters && filters[0] && filters[0].type;
 
         return type === 'date'
@@ -718,7 +718,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
     var value = options.value;
 
     // Invalid value. Do nothing.
-    if (!value) {
+    if (_.isNil(value) || value === false) {
       return;
     }
 


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1789

Follows https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/657

This will allow 0 as filter value whereas it used to be excluded since it was falsey and excluded by `_.pickBy()`.