### PR TITLE
OD-677 [Fix] Adjusted paddings for correct display of the "close" button on tablet/web for News Feed layout

### DIFF
--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -1529,7 +1529,7 @@ html.ie11 .new-news-feed-list-container .news-feed-list-item:not(.open) .slide-o
 
 @media screen and (min-width: 640px) {
   .news-feed-detail-overlay .news-feed-detail-wrapper .news-feed-item-inner-content {
-    padding: 20px 15px;
+    padding: 60px 15px 20px 15px;
   }
 
   .news-feed-detail-overlay .news-feed-detail-overlay-wrapper {


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-677 https://weboo.atlassian.net/browse/OD-677

## Description
**Problem:** Wrong paddings are specified and because of this, the close button merges with the like and save buttons.
**Solution:** Added new paddings that corrected the position of the elements.

## Screenshots/screencasts
https://storyxpress.co/video/ky8pnz1hysxp6fi69

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko