### PR TITLE
OD-699 [Fix] Adjusted bookmark displaying on tablet/web for Directory layout without images

### DIFF
--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -1246,6 +1246,7 @@
     padding: 40px 40px;
   }
 
+  .small-card-detail-overlay-wrapper .small-card-detail-overlay-panel .small-card-detail-overlay-content .small-card-list-detail-content-scroll-wrapper .small-card-list-detail-content-wrapper,
   .small-card-detail-overlay.ready .small-card-detail-wrapper .small-card-list-detail-image-wrapper + .small-card-list-detail-content-scroll-wrapper .small-card-list-detail-content-wrapper {
     padding: 60px 40px 40px 40px;
     border-radius: 0;


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-699 https://weboo.atlassian.net/browse/OD-699

## Description
**Problem:** Correct paddings are set only when there are images in the detailed view.
**Solution:** The same styles are added for detailed view without images.

## Screenshots/screencasts
https://storyxpress.co/video/kycj7m67lnj9yxsnj

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko