### PR TITLE
ID-1674 [Feat] Adds file mode when opening entries

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -600,6 +600,7 @@
                     <option disabled>------</option>
                     <option value="screen">Screen</option>
                     <option value="url">URL</option>
+                    <option value="file">File</option>
                   </select>
                 </div>
               </div>

--- a/js/utils.js
+++ b/js/utils.js
@@ -2931,7 +2931,9 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       return;
     }
 
-    if (options.summaryLinkAction.type === 'url') {
+    if (options.summaryLinkAction.type === 'file') {
+      Fliplet.Navigate.file(value);
+    } else if (options.summaryLinkAction.type === 'url') {
       Fliplet.Navigate.url(value);
     } else {
       var opt = { transition: 'fade' };


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1674

Requires https://github.com/Fliplet/fliplet-api/pull/5123 for Android to download the file within the app and opening the files through the system instead of using the system browser to download files.