### PR TITLE
ID-2818 [Fix] Parse filter values into suitable types

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1120,6 +1120,25 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
         value: option.value
       };
 
+      // Add filter values as different types
+      if (Array.isArray(filter.value)) {
+        filter.value.forEach(function(value) {
+          if (typeof value !== 'string') {
+            return;
+          }
+
+          // Add number strings as numbers
+          if (!isNaN(value)) {
+            filter.value.push(+value);
+          } else if (/^true|false$/i.test(value)) {
+            // Add boolean strings as booleans
+            filter.value.push(value.toLowerCase() === 'true');
+          }
+        });
+
+        filter.value = _.uniq(filter.value);
+      }
+
       // Set up date filter values
       if (filterIsDateCondition(filter)) {
         // Value will be set with date filter, if required


### PR DESCRIPTION
The following page query:

```
dynamicListPrefilterColumn=ID&dynamicListPrefilterValue=%5B1%2C2%2Ctrue%2Cfalse%5D&dynamicListPrefilterLogic=oneof
```

Produces the following data source query:

![image](https://user-images.githubusercontent.com/290733/212061723-d01ba5c3-f98a-47f3-a39a-daef8bc16382.png)
