### PR TITLE
ID-3404 [FIX] Ensure after login when LFD should show correct orders of created records

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1536,6 +1536,15 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
           };
         }
 
+        if (!query) {
+          query = {
+            order: [
+              ['order', 'ASC'],
+              ['id', 'ASC']
+            ]
+          };
+        }
+
         return connection.find(query);
       });
   }


### PR DESCRIPTION
**Product areas affected**

Studio -> Login -> LFD -> Form

**What does this PR do?**

Implemented code, so after user login, LFD should show all entries in correct ASC order.

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/ID-3404)

**Result**

Uploading 3404.mp4…

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None
