### PR TITLE
ID-3806 [Fix] Prevent legacy MixItUp classes from clashing with generic class names

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -2034,7 +2034,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
             type: field,
             data: {
               name: value,
-              class: _.kebabCase(value)
+              class: 'filter-' + _.kebabCase(value)
             }
           });
         });
@@ -2231,7 +2231,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
 
             record.data['flFilters'].push(filterData);
           } else {
-            var filterClass = _.kebabCase(value);
+            var filterClass = 'filter-' + _.kebabCase(value);
 
             filterData.data.class = filterClass;
 


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-3806