### PR TITLE
ID-3806 Use a unique class pattern for legacy MixItUp classes (#730)

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -2034,7 +2034,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
             type: field,
             data: {
               name: value,
-              class: _.kebabCase(value)
+              class: 'filter-' + _.kebabCase(value)
             }
           });
         });
@@ -2231,7 +2231,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
 
             record.data['flFilters'].push(filterData);
           } else {
-            var filterClass = _.kebabCase(value);
+            var filterClass = 'filter-' + _.kebabCase(value);
 
             filterData.data.class = filterClass;
 


### PR DESCRIPTION
| Title | Owner | PR |
| --- | --- | --- |
ID-3806 [Fix] Prevent legacy MixItUp classes from clashing with generic class names | TW | https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/730 |