### PR TITLE
ID-4143 [fix] LFD data view file field order

### DIFF
--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2464,6 +2464,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
 
 DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
+  var fileList = files && Array.isArray(files) ? files.filter(Boolean) : null;
 
   if (_.isArray(entry.entryDetails) && entry.entryDetails.length) {
     _this.Utils.Record.assignImageContent(_this, entry);
@@ -2480,14 +2481,16 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     var content = '';
 
     if (obj.type === 'file') {
-      if (files && Array.isArray(files)) {
-        var file = files.find(function(fileEntry) {
-          return fileEntry.id === obj.id;
-        });
+      if (!fileList) {
+        return;
+      }
 
-        if (file) {
-          entry.entryDetails.push(file);
-        }
+      var file = fileList.find(function(fileEntry) {
+        return fileEntry.id === obj.id;
+      });
+
+      if (file) {
+        entry.entryDetails.push(file);
       }
 
       return;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2481,16 +2481,16 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
     if (obj.type === 'file') {
       if (files && Array.isArray(files)) {
+        var file = files.find(function(file) {
+          return file.id === obj.id;
+        });
 
-        files.filter(Boolean).forEach((file) => {
-          const fileAlreadyAdded = entry.entryDetails.some(({ id }) => id === file.id);
-
-          if (!fileAlreadyAdded) {
-            entry.entryDetails.push(file);
-          }
-        })
+        if (file) {
+          entry.entryDetails.push(file);
+        }
       }
-      return
+
+      return;
     }
 
     // Define label

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2481,8 +2481,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
     if (obj.type === 'file') {
       if (files && Array.isArray(files)) {
-        var file = files.find(function(file) {
-          return file.id === obj.id;
+        var file = files.find(function(fileEntry) {
+          return fileEntry.id === obj.id;
         });
 
         if (file) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2462,7 +2462,7 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
     });
 };
 
-DynamicList.prototype.addDetailViewData = function(entry) {
+DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
 
   if (_.isArray(entry.entryDetails) && entry.entryDetails.length) {
@@ -2480,7 +2480,17 @@ DynamicList.prototype.addDetailViewData = function(entry) {
     var content = '';
 
     if (obj.type === 'file') {
-      return;
+      if (files && Array.isArray(files)) {
+
+        files.filter(Boolean).forEach((file) => {
+          const fileAlreadyAdded = entry.entryDetails.some(({ id }) => id === file.id);
+
+          if (!fileAlreadyAdded) {
+            entry.entryDetails.push(file);
+          }
+        })
+      }
+      return
     }
 
     // Define label
@@ -2570,21 +2580,7 @@ DynamicList.prototype.showDetails = function(id, listData) {
     detailViewOptions: _this.data.detailViewOptions
   })
     .then(function(files) {
-      entryData = _this.addDetailViewData(entryData);
-
-      if (files && Array.isArray(files)) {
-        _.forEach(files, function(file) {
-          if (!file) {
-            return;
-          }
-
-          var isFileAdded = !!_.find(entryData.entryDetails, { id: file.id });
-
-          if (!isFileAdded) {
-            entryData.entryDetails.push(file);
-          }
-        });
-      }
+      entryData = _this.addDetailViewData(entryData, files);
 
       var beforeShowDetails = Promise.resolve({
         src: src,

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2420,6 +2420,7 @@ DynamicList.prototype.getCommentUsers = function() {
 
 DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
+  var fileList = files && Array.isArray(files) ? files.filter(Boolean) : null;
 
   if (_.isArray(entry.data) && entry.data.length) {
     _this.Utils.Record.assignImageContent(_this, entry);
@@ -2436,14 +2437,16 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     var content = '';
 
     if (obj.type === 'file') {
-      if (files && Array.isArray(files)) {
-        var file = files.find(function(fileEntry) {
-          return fileEntry.id === obj.id;
-        });
+      if (!fileList) {
+        return;
+      }
 
-        if (file) {
-          entry.entryDetails.push(file);
-        }
+      var file = fileList.find(function(fileEntry) {
+        return fileEntry.id === obj.id;
+      });
+
+      if (file) {
+        entry.entryDetails.push(file);
       }
 
       return;

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2418,7 +2418,7 @@ DynamicList.prototype.getCommentUsers = function() {
     });
 };
 
-DynamicList.prototype.addDetailViewData = function(entry) {
+DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
 
   if (_.isArray(entry.data) && entry.data.length) {
@@ -2436,6 +2436,16 @@ DynamicList.prototype.addDetailViewData = function(entry) {
     var content = '';
 
     if (obj.type === 'file') {
+      if (files && Array.isArray(files)) {
+        var file = files.find(function(file) {
+          return file.id === obj.id;
+        });
+
+        if (file) {
+          entry.entryDetails.push(file);
+        }
+      }
+
       return;
     }
 
@@ -2529,21 +2539,7 @@ DynamicList.prototype.showDetails = function(id, listData) {
     detailViewOptions: _this.data.detailViewOptions
   })
     .then(function(files) {
-      entryData = _this.addDetailViewData(entryData);
-
-      if (files && Array.isArray(files)) {
-        _.forEach(files, function(file) {
-          if (!file) {
-            return;
-          }
-
-          var isFileAdded = !!_.find(entryData.entryDetails, { id: file.id });
-
-          if (!isFileAdded) {
-            entryData.entryDetails.push(file);
-          }
-        });
-      }
+      entryData = _this.addDetailViewData(entryData, files);
 
       var beforeShowDetails = Promise.resolve({
         src: src,

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2437,8 +2437,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
     if (obj.type === 'file') {
       if (files && Array.isArray(files)) {
-        var file = files.find(function(file) {
-          return file.id === obj.id;
+        var file = files.find(function(fileEntry) {
+          return fileEntry.id === obj.id;
         });
 
         if (file) {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1987,6 +1987,7 @@ DynamicList.prototype.initializeSocials = function(records) {
 
 DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
+  var fileList = files && Array.isArray(files) ? files.filter(Boolean) : null;
 
   if (_.isArray(entry.entryDetails) && entry.entryDetails.length) {
     _this.Utils.Record.assignImageContent(_this, entry);
@@ -2027,14 +2028,16 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     var content = '';
 
     if (dynamicDataObj.type === 'file') {
-      if (files && Array.isArray(files)) {
-        var file = files.find(function(fileEntry) {
-          return fileEntry.id === dynamicDataObj.id;
-        });
+      if (!fileList) {
+        return;
+      }
 
-        if (file) {
-          entry.entryDetails.push(file);
-        }
+      var file = fileList.find(function(fileEntry) {
+        return fileEntry.id === dynamicDataObj.id;
+      });
+
+      if (file) {
+        entry.entryDetails.push(file);
       }
 
       return;

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1985,7 +1985,7 @@ DynamicList.prototype.initializeSocials = function(records) {
   });
 };
 
-DynamicList.prototype.addDetailViewData = function(entry) {
+DynamicList.prototype.addDetailViewData = function(entry, files) {
   var _this = this;
 
   if (_.isArray(entry.entryDetails) && entry.entryDetails.length) {
@@ -2027,6 +2027,16 @@ DynamicList.prototype.addDetailViewData = function(entry) {
     var content = '';
 
     if (dynamicDataObj.type === 'file') {
+      if (files && Array.isArray(files)) {
+        var file = files.find(function(file) {
+          return file.id === dynamicDataObj.id;
+        });
+
+        if (file) {
+          entry.entryDetails.push(file);
+        }
+      }
+
       return;
     }
 
@@ -2116,21 +2126,7 @@ DynamicList.prototype.showDetails = function(id, listData) {
     detailViewOptions: _this.data.detailViewOptions
   })
     .then(function(files) {
-      entryData = _this.addDetailViewData(entryData);
-
-      if (files && Array.isArray(files)) {
-        _.forEach(files, function(file) {
-          if (!file) {
-            return;
-          }
-
-          var isFileAdded = !!_.find(entryData.entryDetails, { id: file.id });
-
-          if (!isFileAdded) {
-            entryData.entryDetails.push(file);
-          }
-        });
-      }
+      entryData = _this.addDetailViewData(entryData, files);
 
       var beforeShowDetails = Promise.resolve({
         src: src,

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2028,8 +2028,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
     if (dynamicDataObj.type === 'file') {
       if (files && Array.isArray(files)) {
-        var file = files.find(function(file) {
-          return file.id === dynamicDataObj.id;
+        var file = files.find(function(fileEntry) {
+          return fileEntry.id === dynamicDataObj.id;
         });
 
         if (file) {


### PR DESCRIPTION
Follow up to https://github.com/Fliplet/fliplet-widget-dynamic-lists/pull/734

This PR changes the way the file fields are rendered in detailed views. Instead of being rendered at the end, they are rendered according to defined field order.

[ID-4143](https://weboo.atlassian.net/browse/ID-4143)

## Results

<img width="919" alt="image" src="https://github.com/Fliplet/fliplet-widget-dynamic-lists/assets/144125903/2a2a0650-0ed6-4f29-b581-884b944ec7ce">

<img width="377" alt="image" src="https://github.com/Fliplet/fliplet-widget-dynamic-lists/assets/144125903/dfcd46cf-68ad-4796-9207-51093eda0639">


[ID-4143]: https://weboo.atlassian.net/browse/ID-4143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ