### PR TITLE
Fix URL protocol handling in detail views

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -406,6 +406,20 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       return formattedName;
     });
 
+    Handlebars.registerHelper('ensureProtocol', function(url) {
+      if (!url) {
+        return '';
+      }
+
+      // Check if URL already has a protocol (http://, https://, //, or other protocols like mailto:, tel:)
+      if (/^(https?:\/\/|\/\/|[a-zA-Z][a-zA-Z\d+\-.]*:)/i.test(url)) {
+        return url;
+      }
+
+      // Add https:// protocol for URLs without one
+      return 'https://' + url;
+    });
+
     Handlebars.registerPartial('filter', Fliplet.Widget.Templates['templates.build.filter']());
   }
 

--- a/templates/build/agenda-cards-detail.build.hbs
+++ b/templates/build/agenda-cards-detail.build.hbs
@@ -97,7 +97,7 @@
       \{{/if}}
 
       <div class="agenda-item-detail-body-text">
-        <a href="\{{{auth content}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"}}</a>
+        <a href="\{{{auth (ensureProtocol content)}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"}}</a>
       </div>
       \{{/if}}
       \{{/ifCond}}

--- a/templates/build/news-feed-detail.build.hbs
+++ b/templates/build/news-feed-detail.build.hbs
@@ -111,7 +111,7 @@
         \{{/if}}
 
         <div class="news-feed-detail-value">
-          <a href="\{{{auth content}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
+          <a href="\{{{auth (ensureProtocol content)}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
             }}</a>
         </div>
         \{{/if}}

--- a/templates/build/simple-list-detail.build.hbs
+++ b/templates/build/simple-list-detail.build.hbs
@@ -54,7 +54,7 @@
   \{{/if}}
 
   <div class="simple-list-detail-value">
-    <a href="\{{{auth content}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText" }}</a>
+    <a href="\{{{auth (ensureProtocol content)}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText" }}</a>
   </div>
   \{{/if}}
   \{{/ifCond}}

--- a/templates/build/small-card-detail.build.hbs
+++ b/templates/build/small-card-detail.build.hbs
@@ -47,7 +47,7 @@
       \{{/if}}
       \{{#if [Linkedin]}}
       <div class="small-card-list-detail-button">
-        <a href="\{{[Linkedin]}}" target="_blank" class="focus-outline" tabindex="0">
+        <a href="\{{ensureProtocol [Linkedin]}}" target="_blank" class="focus-outline" tabindex="0">
           <div class="small-card-list-detail-button-image"><span
               class="fa fa-linkedin"
             ></span></div>
@@ -114,7 +114,7 @@
       \{{/if}}
 
       <div class="small-card-list-detail-body-text">
-        <a href="\{{{auth content}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
+        <a href="\{{{auth (ensureProtocol content)}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
           }}</a>
       </div>
       \{{/if}}

--- a/templates/build/small-h-card-detail.build.hbs
+++ b/templates/build/small-h-card-detail.build.hbs
@@ -35,7 +35,7 @@
       \{{/if}}
       \{{#if [Linkedin]}}
       <div class="small-h-card-list-detail-button">
-        <a href="\{{[Linkedin]}}" target="_blank" class="focus-outline">
+        <a href="\{{ensureProtocol [Linkedin]}}" target="_blank" class="focus-outline">
           <div class="small-h-card-list-detail-button-image"><span
               class="fa fa-linkedin"
             ></span></div>
@@ -102,7 +102,7 @@
       \{{/if}}
 
       <div class="small-h-card-list-detail-body-text">
-        <a href="\{{{auth content}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
+        <a href="\{{{auth (ensureProtocol content)}}}" target="_blank">\{{ T "widgets.list.dynamic.detail.linkText"
           }}</a>
       </div>
       \{{/if}}


### PR DESCRIPTION
Added ensureProtocol Handlebars helper to automatically prepend https:// to URLs without a protocol. This prevents broken URLs when users enter links without http:// or https:// prefix.

Changes:
- Added ensureProtocol helper in utils.js that checks if URL has a protocol
- Updated all 5 detail view templates to use ensureProtocol for URL fields
- Updated LinkedIn field links in small-card and small-h-card templates

The helper intelligently:
- Returns empty string for null/undefined URLs
- Preserves URLs that already have http://, https://, or other protocols (mailto:, tel:, etc.)
- Adds https:// prefix to URLs without a protocol (e.g., www.example.com)

Fixes PS-289 where URLs like www.fliplet.com were being opened as relative URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * URLs are now automatically normalised with proper HTTPS protocols when absent, ensuring consistent and secure link handling across detail views and card layouts.

* **Bug Fixes**
  * Fixed improper URL formatting in agenda cards, news feeds, list details, and card components by enforcing protocol standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->