### PR TITLE
PS-1239 [FIX] Remove hardcoded search icon color

### DIFF
--- a/css/layout-css/agenda-style.upload.css
+++ b/css/layout-css/agenda-style.upload.css
@@ -427,7 +427,6 @@
   top: 0;
   left: 0;
   z-index: 1;
-  color: #337ab7;
   width: 38px;
   height: 100%;
   font-size: 1.2em;

--- a/css/layout-css/news-feed-style.upload.css
+++ b/css/layout-css/news-feed-style.upload.css
@@ -342,7 +342,6 @@
   top: 0;
   left: 0;
   z-index: 1;
-  color: #337ab7;
   width: 38px;
   height: 100%;
   font-size: 1.2em;

--- a/css/layout-css/simple-list-style.upload.css
+++ b/css/layout-css/simple-list-style.upload.css
@@ -336,7 +336,6 @@
   top: 0;
   left: 0;
   z-index: 1;
-  color: #337ab7;
   width: 38px;
   height: 100%;
   font-size: 1.2em;

--- a/css/layout-css/small-card-style.upload.css
+++ b/css/layout-css/small-card-style.upload.css
@@ -401,7 +401,6 @@
   top: 0;
   left: 0;
   z-index: 1;
-  color: #337ab7;
   width: 38px;
   height: 100%;
   font-size: 1.2em;


### PR DESCRIPTION
## Summary
- Removed hardcoded blue color (#337ab7) from search icon across all layouts
- Search icons now properly inherit color from theme appearance settings
- Fixed for: Agenda, Simple List, Small Card, and News Feed layouts

## Changes
- `css/layout-css/agenda-style.upload.css` - Removed color from `.new-agenda-list-container .search-holder .fa`
- `css/layout-css/simple-list-style.upload.css` - Removed color from `.simple-list-container .search-holder .fa.fa-search`
- `css/layout-css/small-card-style.upload.css` - Removed color from `.new-small-card-list-container .search-holder .fa`
- `css/layout-css/news-feed-style.upload.css` - Removed color from `.new-news-feed-list-container .search-holder .fa`

## Test plan
- [ ] Verify search icon color in Agenda layout respects theme appearance settings
- [ ] Verify search icon color in Simple List layout respects theme appearance settings
- [ ] Verify search icon color in Small Card layout respects theme appearance settings
- [ ] Verify search icon color in News Feed layout respects theme appearance settings
- [ ] Test with different theme colors to ensure icons update correctly
- [ ] Verify no visual regressions in layouts without custom appearance settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)