### PR TITLE
PS-1550 [FIX] Prevent detail view crash when image field is null

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -217,7 +217,12 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       imagesArray = content;
     }
 
-    imageContent = imagesArray
+    // Ensure imagesArray is always an array to prevent null/undefined errors
+    if (!Array.isArray(imagesArray)) {
+      imagesArray = [];
+    }
+
+    imageContent = imagesArray.length > 0
       ? imagesArray[0]
       : '';
 


### PR DESCRIPTION
## Summary
- Fixed a critical bug where the detail view would not open when clicking list items with empty/null image fields
- Added null/undefined check to prevent JavaScript error in `getImageContent` function (js/utils.js:221-223)
- Ensures `imagesArray` is always a valid array before calling `.map()`

## Problem
Users reported getting error: `Uncaught (in promise) TypeError: can't access property "map", imagesArray is null` when trying to open detail view for entries where the image field is empty. This prevented the detail overlay from opening entirely.

## Solution
- Added `Array.isArray()` check after assigning to `imagesArray` to ensure it's always an array
- If `imagesArray` is null/undefined, it defaults to an empty array
- Updated the `imageContent` check to use `imagesArray.length > 0` for clearer logic

## Test plan
- [ ] Test detail view with entries that have empty/null image fields
- [ ] Verify detail overlay opens without errors
- [ ] Test detail view with entries that have valid images
- [ ] Verify existing functionality still works correctly

## Related
- Ticket: PS-1550
- Related to PS-1527 (similar image field issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)