### PR TITLE
PS-1885 [FIX] LFD bookmarks should work offline

### DIFF
--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -2318,7 +2318,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           addType: 'prepend',
           getAllCounts: false,
           liked: record.bookmarked,
-          silent: record.bookmarkButton
+          silent: record.bookmarkButton,
+          offline: true
         });
 
         if (record.bookmarkButton) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2578,7 +2578,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="news-feed-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2313,7 +2313,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="simple-list-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1943,7 +1943,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="small-card-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;


### PR DESCRIPTION
## Summary

- Pass `offline: true` to the `LikeButton` instance behind each layout's bookmark control (simple-list, news-feed, small-card, agenda).
- This unblocks the "Please connect to the internet" popup that was firing every time a user tapped a bookmark while offline, so the toggle now reaches the data source connector which already handles offline queueing and reconnect replay.
- Like buttons are intentionally left as-is — they remain online-only because the like count is a shared online concept. Bookmarks are a per-user toggle that users (and the support docs) expect to keep working offline.

Fixes [PS-1885](https://weboo.atlassian.net/browse/PS-1885).

## Companion PR

This depends on the `offline` option being added to `LikeButton`:
- `fliplet-api` PR: https://github.com/Fliplet/fliplet-api/pull/7948

## Test plan

- [ ] In each layout (simple-list, news-feed, small-card, agenda): airplane mode → tap a bookmark → no popup; bookmark icon flips to filled state; bookmarked-only filter still works.
- [ ] Reconnect → confirm the bookmark/unbookmark write was synced server-side (check the bookmarks data source).
- [ ] Like button on a news-feed list still shows the "Please connect to the internet" popup when offline (regression check).
- [ ] Cold offline relaunch (with bundled DS): bookmark state from previous online session still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1885]: https://weboo.atlassian.net/browse/PS-1885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ