### PR TITLE
Release/PS-1885 — LFD bookmarks offline + bundled staging fixes

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,124 @@
+# Fliplet Widget Development Context
+
+## Project Overview
+This is a Fliplet widget/component built using the Fliplet platform's component architecture.
+Fliplet is a no-code app development platform with a custom widget system.
+
+## Critical Documentation
+- Main docs: https://developers.fliplet.com/
+- JS APIs: https://developers.fliplet.com/API-Documentation.html
+- Component structure: https://developers.fliplet.com/Building-components.html
+- CLI docs: https://developers.fliplet.com/Quickstart.html
+
+## Technology Stack
+- Vue 3 (Composition API)
+- Pinia for state management
+- Vite for tooling
+- Pure JavaScript (no TypeScript)
+- Fliplet CLI 7.0.1
+
+## Fliplet-Specific Patterns
+
+### Component Structure
+- `widget.html` - Main interface file
+- `widget.js` - Widget logic and Fliplet API calls
+- `widget.json` - Widget configuration
+- Follow Fliplet's component structure guidelines exactly
+
+### Fliplet API Usage
+- Always use Fliplet.* namespace for API calls
+- Data Sources: Use Fliplet.DataSources API
+- Navigation: Use Fliplet.Navigate API
+- Check documentation before implementing Fliplet-specific features
+
+## Development Workflow
+
+### Branch Strategy and PR Process
+1. **Assign ticket**: Re-assign JIRA ticket to yourself and read the issue thoroughly
+2. **Create project branch** from `master`:
+   - Format: `project/{TICKET-NUMBER}-{DESCRIPTION}`
+   - Example: `projects/farhad-platform-support/PS-78`
+   - Command: `git checkout -b project/{TICKET-NUMBER}-{DESCRIPTION} master`
+3. **Create feature/fix branch** from your project branch:
+   - Format: `feature/{description}` or `fix/{description}`
+   - Command: `git checkout -b feature/{description}`
+4. **Push changes** to feature/fix branch and raise PR with base as the project branch
+5. **Check automation testing**: Ensure no errors from automated tests
+6. **Request review**: Post in #scrum-buddies Slack channel for code review
+7. **Move to Q&A**: Once PR approved, move JIRA card to Q&A status
+8. **QA handles merge**: QA team manages merge to staging (not developer responsibility)
+
+### CLI Commands
+- `fliplet run` - Test locally
+- `fliplet publish` - Publish widget
+- Test locally before publishing
+- Never modify Fliplet core APIs
+
+## Code Safety and Stability Requirements
+
+### CRITICAL: Minimal Changes Philosophy
+**DO NOT make radical or sweeping changes to the codebase**
+- Make surgical, targeted fixes only
+- Preserve existing patterns and architecture
+- Don't refactor working code unless explicitly required by ticket
+- Avoid "while we're here" improvements
+- If code works but looks ugly, leave it alone unless ticket requires cleanup
+- Changes should be minimal and directly address the ticket requirements
+
+### Package Management
+**ALWAYS ask user before updating packages**
+- Some packages (especially ESLint) have breaking API changes
+- Check package changelogs before suggesting updates
+- Get explicit approval for any package updates
+- Test thoroughly after any package changes
+- Document why package update is necessary
+
+### What Requires User Confirmation
+❓ Any package updates (npm/yarn)
+❓ Changes to build configuration (Vite, webpack)
+❓ Modifications to ESLint rules or config
+❓ Changes to existing working functionality
+❓ Refactoring that isn't explicitly requested
+
+### What Can Be Done Without Asking
+✅ Bug fixes matching ticket description
+✅ Adding new features per ticket requirements
+✅ Writing tests for new/changed code
+✅ Fixing actual errors or warnings
+✅ Code formatting (if already established)
+
+## Testing Requirements
+**CRITICAL: All code changes must include functional tests**
+- Focus on functional testing only (not visual/UI testing)
+- Test Fliplet API interactions
+- Test data flow and state management
+- Test user interactions and event handlers
+- Use Jest or similar for unit tests
+- Test coverage should focus on logic, not rendering
+
+### What to Test
+✅ Data transformations
+✅ API calls and responses
+✅ Event handlers and callbacks
+✅ State mutations (Pinia stores)
+✅ Error handling
+✅ Business logic
+
+❌ Visual appearance
+❌ CSS styling
+❌ Layout positioning
+❌ Responsive breakpoints
+
+## Code Style
+- Use ES6+ syntax
+- Destructure imports: `import { ref, computed } from 'vue'`
+- Prefer arrow functions for callbacks
+- Keep components modular and reusable
+- Follow existing code patterns in the file being modified
+
+## Common Pitfalls
+- Don't assume standard Node.js APIs are available in Fliplet runtime
+- Always check Fliplet API documentation for correct usage
+- Test on Fliplet platform, not just locally
+- Don't break existing functionality with "improvements"
+- Respect the existing codebase structure and patterns

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -2318,7 +2318,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           addType: 'prepend',
           getAllCounts: false,
           liked: record.bookmarked,
-          silent: record.bookmarkButton
+          silent: record.bookmarkButton,
+          offline: true
         });
 
         if (record.bookmarkButton) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2578,7 +2578,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="news-feed-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -1146,6 +1146,36 @@ DynamicList.prototype.attachObservers = function() {
       _this.imagesData[id].options.index = $this.index();
 
       Fliplet.Navigate.previewImages(_this.imagesData[id]);
+    })
+    .on('click keydown', '.news-feed-detail-wrapper a[href^="#"]', function(event) {
+      if (!_this.Utils.accessibilityHelpers.isExecute(event)) {
+        return;
+      }
+
+      var href = this.getAttribute('href');
+
+      if (!href || href === '#') {
+        return;
+      }
+
+      var targetId = decodeURIComponent(href.slice(1));
+      var selector = '#' + (window.CSS && window.CSS.escape ? window.CSS.escape(targetId) : targetId);
+      var $target = _this.$overlay.find(selector);
+      var $container = $target.closest('.news-feed-list-detail-content-scroll-wrapper');
+
+      if (!$container.length) {
+        $container = _this.$overlay.find('.news-feed-detail-overlay-content');
+      }
+
+      if (!$target.length || !$container.length) {
+        return;
+      }
+
+      event.preventDefault();
+
+      var targetTop = ($target.offset().top - $container.offset().top) + $container.scrollTop();
+
+      $container.stop().animate({ scrollTop: targetTop }, 300);
     });
 };
 
@@ -2705,7 +2735,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     // Define content
     if (obj.customFieldEnabled) {
       content = new Handlebars.SafeString(Handlebars.compile(obj.customField)(entry.originalData));
-    } else if (_this.data.filterFields.indexOf(obj.column) > -1) {
+    } else if (_this.data.filterFields.indexOf(obj.column) > -1
+      && obj.type !== 'html') {
       content = _this.Utils.String.splitByCommas(entry.originalData[obj.column]).join(', ');
     } else {
       content = entry.originalData[obj.column];

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2671,7 +2671,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     // Define content
     if (obj.customFieldEnabled) {
       content = new Handlebars.SafeString(Handlebars.compile(obj.customField)(entry.originalData));
-    } else if (_this.data.filterFields.indexOf(obj.column) > -1) {
+    } else if (_this.data.filterFields.indexOf(obj.column) > -1
+      && obj.type !== 'html') {
       content = _this.Utils.String.splitByCommas(entry.originalData[obj.column]).join(', ');
     } else {
       content = entry.originalData[obj.column];

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2313,7 +2313,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="simple-list-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2195,7 +2195,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
       if (obj.column === 'custom') {
         content = new Handlebars.SafeString(Handlebars.compile(obj.customField)(entry.originalData));
-      } else if (_this.data.filterFields.indexOf(obj.column) > -1) {
+      } else if (_this.data.filterFields.indexOf(obj.column) > -1
+        && obj.type !== 'html') {
         content = _this.Utils.String.splitByCommas(entry.originalData[obj.column]).join(', ');
       } else {
         content = entry.originalData[obj.column];
@@ -2243,7 +2244,8 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
     // Define content
     if (dynamicDataObj.customFieldEnabled) {
       content = new Handlebars.SafeString(Handlebars.compile(dynamicDataObj.customField)(entry.originalData));
-    } else if (_this.data.filterFields.indexOf(dynamicDataObj.column) > -1) {
+    } else if (_this.data.filterFields.indexOf(dynamicDataObj.column) > -1
+      && dynamicDataObj.type !== 'html') {
       content = _this.Utils.String.splitByCommas(entry.originalData[dynamicDataObj.column]).join(', ');
     } else {
       content = entry.originalData[dynamicDataObj.column];

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -1943,7 +1943,8 @@ DynamicList.prototype.setupBookmarkButton = function(options) {
           likedWrapper: '<div class="small-card-bookmark-wrapper btn-bookmarked focus-outline" tabindex="0"></div>',
           addType: 'html',
           getAllCounts: false,
-          liked: record.bookmarked
+          liked: record.bookmarked,
+          offline: true
         });
 
         record.bookmarkButton = btn;

--- a/js/utils.js
+++ b/js/utils.js
@@ -213,17 +213,38 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
   }
 
   function getImageContent(content, isSummary) {
+    // Handle null, undefined, or empty content
+    if (!content || content === '') {
+      if (isSummary) {
+        return '';
+      }
+
+      return {
+        imageContent: '',
+        imagesArray: [],
+        imagesData: {
+          images: [],
+          options: {
+            index: null
+          }
+        }
+      };
+    }
+
     var imageContent;
     var imagesArray = [];
     var isString = typeof content === 'string';
 
     if (isString) {
       imagesArray = getImagesUrlsByRegex(content) || [];
-    } else {
+    } else if (Array.isArray(content)) {
       imagesArray = content || [];
+    } else {
+      // If content is not a string or array, default to empty array
+      imagesArray = [];
     }
 
-    imageContent = imagesArray
+    imageContent = imagesArray && imagesArray.length
       ? imagesArray[0]
       : '';
 
@@ -238,13 +259,16 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
       }
     };
 
-    imagesData.images = Array.isArray(imagesArray) ? imagesArray.map(function(imgUrl) {
-      return { url: imgUrl };
-    }) : [];
+    // Ensure imagesArray is always an array before calling map
+    imagesData.images = (imagesArray && Array.isArray(imagesArray))
+      ? imagesArray.map(function(imgUrl) {
+          return { url: imgUrl };
+        })
+      : [];
 
     return {
       imageContent: imageContent,
-      imagesArray: imagesArray,
+      imagesArray: imagesArray || [],
       imagesData: imagesData
     };
   }
@@ -723,52 +747,55 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
     options = options || {};
 
     var $container = options.$container;
-    var activeFilters = _($container.find('[data-filter-group] .hidden-filter-controls-filter.mixitup-control-active').not('[data-type="date"], [data-type="number"]'))
-      .map(function(el) {
-        return NativeUtils.pickBy({
-          class: el.dataset.toggle,
-          field: el.dataset.field,
-          value: el.dataset.value
-        });
-      })
-      .groupBy('field')
-      .mapValues(function(filters) {
-        return filters.map(function(filter) {
-          return NativeUtils.has(filter, 'field') && NativeUtils.has(filter, 'value')
-            ? filter.value
-            : filter.class;
-        });
-      })
-      .value();
+    var elements = $container.find('[data-filter-group] .hidden-filter-controls-filter.mixitup-control-active').not('[data-type="date"], [data-type="number"]');
+    var mappedFilters = Array.from(elements).map(function(el) {
+      return NativeUtils.pickBy({
+        class: el.dataset.toggle,
+        field: el.dataset.field,
+        value: el.dataset.value
+      });
+    });
+    var groupedFilters = NativeUtils.groupBy(mappedFilters, 'field');
+    var activeFilters = Object.keys(groupedFilters).reduce(function(result, key) {
+      result[key] = groupedFilters[key].map(function(filter) {
+        return NativeUtils.has(filter, 'field') && NativeUtils.has(filter, 'value')
+          ? filter.value
+          : filter.class;
+      });
+
+      return result;
+    }, {});
 
     var inputDataNames = {
       date: 'flDatePicker',
       number: 'flNumberInput'
     };
-    var rangeFilters = _($container.find('[data-filter-group] .hidden-filter-controls-filter.mixitup-control-active').filter('[data-type="date"], [data-type="number"]'))
-      .map(function(el) {
-        var $el = $(el);
-        var type = $el.data('type');
+    var rangeElements = $container.find('[data-filter-group] .hidden-filter-controls-filter.mixitup-control-active').filter('[data-type="date"], [data-type="number"]');
+    var mappedRangeFilters = Array.from(rangeElements).map(function(el) {
+      var $el = $(el);
+      var type = $el.data('type');
 
-        return NativeUtils.omitBy({
-          field: el.dataset.field,
-          type: type,
-          value: $el.data(inputDataNames[type]).get()
-        }, NativeUtils.isNil);
-      })
-      .groupBy('field')
-      .mapValues(function(filters) {
-        // Sort the values to assume the FROM value is not after the TO value
-        var values = filters.map(function(f) { return f.value; });
-        var type = filters && filters[0] && filters[0].type;
+      return NativeUtils.omitBy({
+        field: el.dataset.field,
+        type: type,
+        value: $el.data(inputDataNames[type]).get()
+      }, NativeUtils.isNil);
+    });
+    var groupedRangeFilters = NativeUtils.groupBy(mappedRangeFilters, 'field');
+    var rangeFilters = Object.keys(groupedRangeFilters).reduce(function(result, key) {
+      var filters = groupedRangeFilters[key];
+      // Sort the values to assume the FROM value is not after the TO value
+      var values = filters.map(function(f) { return f.value; });
+      var type = filters && filters[0] && filters[0].type;
 
-        return type === 'date'
-          ? values.sort()
-          : values.sort(function(a, b) {
-            return a - b;
-          });
-      })
-      .value();
+      result[key] = type === 'date'
+        ? values.sort()
+        : values.sort(function(a, b) {
+          return a - b;
+        });
+
+      return result;
+    }, {});
 
     // Clean up invalid date filter values
     for (var field in rangeFilters) {
@@ -2245,60 +2272,59 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
     }
 
     // Parse legacy flFilters from records to generate a list of filter values
-    var result = _(records)
-      .map(function(record) {
-        return (record.data && record.data.flFilters) || record.flFilters;
-      })
-      .flatten()
-      .uniqBy(function(filter) {
-        // Ignore the filter class name when computing unique filter values
-        if (filter.data && filter.data.class) {
-          delete filter.data.class;
-        }
+    var mappedRecords = records.map(function(record) {
+      return (record.data && record.data.flFilters) || record.flFilters;
+    });
+    var flattenedFilters = NativeUtils.flatten(mappedRecords);
+    var uniqueFilters = NativeUtils.uniqBy(flattenedFilters, function(filter) {
+      // Ignore the filter class name when computing unique filter values
+      if (filter.data && filter.data.class) {
+        delete filter.data.class;
+      }
 
-        // uniqBy iteratee, ignoring classes
-        return JSON.stringify(filter);
-      })
-      .orderBy(function(obj) {
-        return (NativeUtils.get(obj, ['data', 'name'], '') + '').toLowerCase();
-      })
-      .groupBy('type')
-      .map(function(values, field) {
-        // map iteratee for defining of each filter field
-        var filter  = {
-          id: id,
-          name: field,
-          data: values.map(function(v) { return v.data; }),
-          type: filterTypes[field]
-        };
+      // uniqBy iteratee, ignoring classes
+      return JSON.stringify(filter);
+    });
+    var orderedFilters = NativeUtils.orderBy(uniqueFilters, function(obj) {
+      return (NativeUtils.get(obj, ['data', 'name'], '') + '').toLowerCase();
+    });
+    var groupedByType = NativeUtils.groupBy(orderedFilters, 'type');
+    var mappedFilters = Object.keys(groupedByType).map(function(field) {
+      var values = groupedByType[field];
+      // map iteratee for defining of each filter field
+      var filter  = {
+        id: id,
+        name: field,
+        data: values.map(function(v) { return v.data; }),
+        type: filterTypes[field]
+      };
 
-        switch (filter.type) {
-          case 'date':
-          case 'number':
-            Object.assign(filter, getMinMaxFilterValues(values));
+      switch (filter.type) {
+        case 'date':
+        case 'number':
+          Object.assign(filter, getMinMaxFilterValues(values));
 
-            // If min/max values can't be found, render the filter as a toggle
-            if (!NativeUtils.has(filter, 'min') || !NativeUtils.has(filter, 'max')) {
-              filterTypes[field] = 'toggle';
-              filter.type = 'toggle';
-            }
+          // If min/max values can't be found, render the filter as a toggle
+          if (!NativeUtils.has(filter, 'min') || !NativeUtils.has(filter, 'max')) {
+            filterTypes[field] = 'toggle';
+            filter.type = 'toggle';
+          }
 
-            break;
-          case 'toggle':
-          default:
-            break;
-        }
+          break;
+        case 'toggle':
+        default:
+          break;
+      }
 
-        return filter;
-      })
-      .filter(function(filter) {
-        return filter.name && NativeUtils.size(filter.data);
-      })
-      .orderBy(function(filter) {
-        // orderBy iteratee
-        return filters.indexOf(filter.name);
-      })
-      .value();
+      return filter;
+    });
+    var filteredResults = mappedFilters.filter(function(filter) {
+      return filter.name && NativeUtils.size(filter.data);
+    });
+    var result = NativeUtils.orderBy(filteredResults, function(filter) {
+      // orderBy iteratee
+      return filters.indexOf(filter.name);
+    });
 
     // Remove the fake entry added from filter query
     if (hasFilterQuery) {
@@ -2505,8 +2531,10 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
 
           if (typeof image === 'string') {
             images = splitByCommas(image);
-          } else {
+          } else if (Array.isArray(image)) {
             images = image;
+          } else {
+            images = [];
           }
 
           response.files.forEach(function(file) {
@@ -2565,7 +2593,7 @@ Fliplet.Registry.set('dynamicListUtils', (function() {
               NativeUtils.set(data, ['record', 'data', data.field.column], file.url);
 
               return true;
-            } else if (Static.RegExp.number.test(image)
+            } else if (image && Static.RegExp.number.test(image)
             && parseInt(image, 10) === file.id) {
               NativeUtils.set(data, ['record', 'data', data.field.column], file.url);
 


### PR DESCRIPTION
## Summary

Production release rolling up staging. The headline change is **PS-1885** (bookmarks should work offline in List From Data Source); several already-merged-to-staging fixes ride along.

## Changes in this release

### PS-1885 — LFD bookmarks should work offline (new)
- Pass `offline: true` to the `LikeButton` wrapping the bookmark control in **simple-list**, **news-feed**, **small-card**, and **agenda** layouts.
- Eliminates the "Please connect to the internet" popup when tapping a bookmark offline. The data source connector queues the write to its outbox and replays on reconnect.
- Like buttons are intentionally left online-only (the count is a shared online concept). Bookmarks are a per-user toggle users expect to keep working offline.

### Bundled from staging (already reviewed in their original PRs)
- **PS-1492** — Anchor links (`href="#..."`) inside the news-feed detail overlay now scroll within the overlay container instead of navigating away.
- **PS-1492** — HTML-typed columns in `filterFields` are no longer split by commas in detail views (news-feed, simple-list, small-card).
- **PS-1494** — `getImageContent` hardened against `null`, `undefined`, empty, and non-string/non-array inputs.
- **DEV-836** — Removed remaining lodash chain usage in `js/utils.js`, replacing with `NativeUtils` equivalents.

## Test plan

- [ ] **Offline bookmark (PS-1885)** — Open an LFD screen on device, enable airplane mode, tap a bookmark on the list and on the detail view across all four layouts. Verify no "Please connect to the internet" popup, the bookmark icon toggles, and reconnecting replays the change to the data source.
- [ ] **Online bookmark regression** — Same flow online; confirm bookmark still persists.
- [ ] **Like button regression** — Confirm like buttons still show the offline warning when tapped offline (intentionally unchanged).
- [ ] **Anchor links (PS-1492)** — Open a news-feed detail view containing internal `#anchor` links; verify clicks/keyboard activations scroll within the overlay.
- [ ] **HTML filter columns (PS-1492)** — Detail view of records whose filter column is HTML-typed renders without comma-splitting.
- [ ] **Filters smoke test (DEV-836)** — Exercise text/toggle, date range, and number range filters on a screen that uses them; confirm no regressions from the lodash → NativeUtils refactor.
- [ ] **Image rendering (PS-1494)** — Records with empty/null image fields render without errors.
- [ ] **Codacy** — Resolve outstanding static-analysis findings before merge.

## Tickets

- https://fliplet.atlassian.net/browse/PS-1885