### PR TITLE
PS-1879 [FIX] Detail view fields no longer repopulate after deletion

### DIFF
--- a/__tests__/detail-view-auto-update.test.js
+++ b/__tests__/detail-view-auto-update.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for PS-1879: detail-view fields must not repopulate after deletion.
+ *
+ * When "auto update when new fields are added" is on, the merge logic only adds
+ * columns that are genuinely new to the data source. A column the user removed is
+ * recorded in the detailViewKnownColumns snapshot, so it is excluded from the
+ * re-add. These tests cover the two primitives that combine to produce that
+ * behaviour (NativeUtils.difference variadic + NativeUtils.coalesceArray) and the
+ * empty-snapshot edge case that would otherwise silently resurrect the bug.
+ */
+
+/* eslint-env jest */
+
+var path = require('path');
+
+// native-utils.js assigns to `window.NativeUtils`; expose `window` then require it.
+global.window = global.window || {};
+require(path.join(__dirname, '..', 'js', 'native-utils.js'));
+
+var NativeUtils = global.window.NativeUtils;
+
+describe('PS-1879 — NativeUtils.difference (variadic exclusion)', function() {
+  it('returns only columns absent from BOTH saved options and the known snapshot', function() {
+    var dsColumns = ['name', 'email', 'phone', 'newCol'];
+    var savedColumns = ['name', 'email'];
+    var knownColumns = ['name', 'email', 'phone']; // phone deleted by user: known, not saved
+
+    expect(NativeUtils.difference(dsColumns, savedColumns, knownColumns)).toEqual(['newCol']);
+  });
+
+  it('re-adds nothing when every data source column is already known', function() {
+    var dsColumns = ['a', 'b'];
+
+    expect(NativeUtils.difference(dsColumns, ['a'], ['a', 'b'])).toEqual([]);
+  });
+});
+
+describe('PS-1879 — NativeUtils.coalesceArray (empty-snapshot guard)', function() {
+  it('keeps a non-empty snapshot', function() {
+    expect(NativeUtils.coalesceArray(['a'], ['x', 'y'])).toEqual(['a']);
+  });
+
+  it('falls back when the snapshot is an empty array (truthy-empty footgun)', function() {
+    expect(NativeUtils.coalesceArray([], ['x', 'y'])).toEqual(['x', 'y']);
+  });
+
+  it('falls back when the snapshot is absent (existing apps with no snapshot)', function() {
+    expect(NativeUtils.coalesceArray(undefined, ['x', 'y'])).toEqual(['x', 'y']);
+    expect(NativeUtils.coalesceArray(null, ['x', 'y'])).toEqual(['x', 'y']);
+  });
+});
+
+describe('PS-1879 — column resolution end to end', function() {
+  // The deleted column ("phone") still exists in the data source but was removed
+  // from the detail view. It must NOT be re-added on any subsequent load/render.
+  function newColumnsToAdd(snapshot, dsColumns, savedColumns) {
+    var knownColumns = NativeUtils.coalesceArray(snapshot, dsColumns);
+
+    return NativeUtils.difference(dsColumns, savedColumns, knownColumns);
+  }
+
+  it('does not re-add a deleted column when a real snapshot exists', function() {
+    var snapshot = ['name', 'email', 'phone'];
+    var dsColumns = ['name', 'email', 'phone'];
+    var savedColumns = ['name', 'email']; // user deleted phone
+
+    expect(newColumnsToAdd(snapshot, dsColumns, savedColumns)).toEqual([]);
+  });
+
+  it('does not re-add a deleted column when the snapshot is empty (the Arpan hazard)', function() {
+    var snapshot = []; // persisted before columns loaded
+    var dsColumns = ['name', 'email', 'phone'];
+    var savedColumns = ['name', 'email']; // user deleted phone
+
+    expect(newColumnsToAdd(snapshot, dsColumns, savedColumns)).toEqual([]);
+  });
+
+  it('still surfaces a genuinely new data source column once a snapshot exists', function() {
+    var snapshot = ['name', 'email']; // columns known as of last save
+    var dsColumns = ['name', 'email', 'phone']; // phone added to the DS afterwards
+    var savedColumns = ['name', 'email'];
+
+    expect(newColumnsToAdd(snapshot, dsColumns, savedColumns)).toEqual(['phone']);
+  });
+});

--- a/js/interface.js
+++ b/js/interface.js
@@ -1186,7 +1186,19 @@ var DynamicLists = (function() {
           }
 
           if (_this.config.detailViewAutoUpdate) {
+            // PS-1879: only auto-add columns that are genuinely NEW to this widget.
+            // detailViewKnownColumns is the snapshot of data source columns as of the
+            // last save. Columns the user intentionally removed are still in this
+            // snapshot, so they are treated as "known" and never re-added. Existing
+            // configs have no snapshot yet — seed it from the current columns so
+            // previously-deleted fields are not re-added on this load.
+            var knownColumns = _this.config.detailViewKnownColumns || dataSourceColumns;
+
             dataSourceColumns.forEach(function(column) {
+              if (knownColumns.indexOf(column) !== -1) {
+                return;
+              }
+
               var foundColumn = _this.config.detailViewOptions.find(function(item) {
                 return column === item.column;
               });
@@ -3016,6 +3028,10 @@ var DynamicLists = (function() {
       _this.saveDetailedViewOptions();
 
       data.detailViewAutoUpdate = $('input#enable-auto-update').is(':checked');
+
+      // PS-1879: snapshot the current data source columns so future "new field"
+      // detection can tell genuinely-new columns from intentionally-removed ones.
+      data.detailViewKnownColumns = dataSourceColumns || _this.config.dataSourceColumns || _this.config.defaultColumns || [];
 
       // Get search and filter
       data.searchEnabled = $('#enable-search').is(':checked');

--- a/js/interface.js
+++ b/js/interface.js
@@ -1190,9 +1190,9 @@ var DynamicLists = (function() {
             // detailViewKnownColumns is the snapshot of data source columns as of the
             // last save. Columns the user intentionally removed are still in this
             // snapshot, so they are treated as "known" and never re-added. Existing
-            // configs have no snapshot yet — seed it from the current columns so
-            // previously-deleted fields are not re-added on this load.
-            var knownColumns = _this.config.detailViewKnownColumns || dataSourceColumns;
+            // configs (or an empty/failed snapshot) fall back to the current columns
+            // so previously-deleted fields are not re-added on this load.
+            var knownColumns = NativeUtils.coalesceArray(_this.config.detailViewKnownColumns, dataSourceColumns);
 
             dataSourceColumns.forEach(function(column) {
               if (knownColumns.indexOf(column) !== -1) {

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -2985,7 +2985,11 @@ DynamicList.prototype.addDetailViewData = function(entry) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = dynamicData.map(function(item) { return item.column; });
-    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns);
+    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
+    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
+    // are absent from BOTH the saved options and the known-columns snapshot. Existing
+    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {
       var newColumnData = {

--- a/js/layout-javascript/agenda-code.js
+++ b/js/layout-javascript/agenda-code.js
@@ -2985,10 +2985,9 @@ DynamicList.prototype.addDetailViewData = function(entry) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = dynamicData.map(function(item) { return item.column; });
-    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
-    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
-    // are absent from BOTH the saved options and the known-columns snapshot. Existing
-    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    // PS-1879: only surface columns genuinely new to the data source; columns the user
+    // removed stay in the known-columns snapshot and are excluded. See interface.js.
+    var knownColumns = NativeUtils.coalesceArray(_this.data.detailViewKnownColumns, _this.dataSourceColumns);
     var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2769,10 +2769,9 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = _this.data.detailViewOptions.map(function(option) { return option.column; });
-    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
-    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
-    // are absent from BOTH the saved options and the known-columns snapshot. Existing
-    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    // PS-1879: only surface columns genuinely new to the data source; columns the user
+    // removed stay in the known-columns snapshot and are excluded. See interface.js.
+    var knownColumns = NativeUtils.coalesceArray(_this.data.detailViewKnownColumns, _this.dataSourceColumns);
     var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     extraColumns.forEach(function(column) {

--- a/js/layout-javascript/news-feed-code.js
+++ b/js/layout-javascript/news-feed-code.js
@@ -2769,7 +2769,11 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = _this.data.detailViewOptions.map(function(option) { return option.column; });
-    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns);
+    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
+    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
+    // are absent from BOTH the saved options and the known-columns snapshot. Existing
+    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     extraColumns.forEach(function(column) {
       var newColumnData = {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2705,10 +2705,9 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(_this.data.detailViewOptions, function(option) { return option.column; });
-    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
-    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
-    // are absent from BOTH the saved options and the known-columns snapshot. Existing
-    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    // PS-1879: only surface columns genuinely new to the data source; columns the user
+    // removed stay in the known-columns snapshot and are excluded. See interface.js.
+    var knownColumns = NativeUtils.coalesceArray(_this.data.detailViewKnownColumns, _this.dataSourceColumns);
     var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {

--- a/js/layout-javascript/simple-list-code.js
+++ b/js/layout-javascript/simple-list-code.js
@@ -2705,7 +2705,11 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(_this.data.detailViewOptions, function(option) { return option.column; });
-    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns);
+    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
+    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
+    // are absent from BOTH the saved options and the known-columns snapshot. Existing
+    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {
       var newColumnData = {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2278,10 +2278,9 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(dynamicData, 'column');
-    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
-    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
-    // are absent from BOTH the saved options and the known-columns snapshot. Existing
-    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    // PS-1879: only surface columns genuinely new to the data source; columns the user
+    // removed stay in the known-columns snapshot and are excluded. See interface.js.
+    var knownColumns = NativeUtils.coalesceArray(_this.data.detailViewKnownColumns, _this.dataSourceColumns);
     var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {

--- a/js/layout-javascript/small-card-code.js
+++ b/js/layout-javascript/small-card-code.js
@@ -2278,7 +2278,11 @@ DynamicList.prototype.addDetailViewData = function(entry, files) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(dynamicData, 'column');
-    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns);
+    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
+    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
+    // are absent from BOTH the saved options and the known-columns snapshot. Existing
+    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {
       var newColumnData = {

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -880,10 +880,9 @@ DynamicList.prototype.addDetailViewData = function(entry) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(dynamicData, 'data');
-    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
-    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
-    // are absent from BOTH the saved options and the known-columns snapshot. Existing
-    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    // PS-1879: only surface columns genuinely new to the data source; columns the user
+    // removed stay in the known-columns snapshot and are excluded. See interface.js.
+    var knownColumns = NativeUtils.coalesceArray(_this.data.detailViewKnownColumns, _this.dataSourceColumns);
     var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {

--- a/js/layout-javascript/small-h-card-code.js
+++ b/js/layout-javascript/small-h-card-code.js
@@ -880,7 +880,11 @@ DynamicList.prototype.addDetailViewData = function(entry) {
 
   if (_this.data.detailViewAutoUpdate) {
     var savedColumns = NativeUtils.map(dynamicData, 'data');
-    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns);
+    var knownColumns = _this.data.detailViewKnownColumns || _this.dataSourceColumns;
+    // PS-1879: exclude columns the user intentionally removed. Genuinely-new columns
+    // are absent from BOTH the saved options and the known-columns snapshot. Existing
+    // configs have no snapshot — seed it from current columns so nothing is re-added.
+    var extraColumns = NativeUtils.difference(_this.dataSourceColumns, savedColumns, knownColumns);
 
     NativeUtils.forEach(extraColumns, function(column) {
       var newColumnData = {

--- a/js/native-utils.js
+++ b/js/native-utils.js
@@ -1323,5 +1323,21 @@ window.NativeUtils = {
       return -1;
     }
     return array.indexOf(value, fromIndex);
+  },
+
+  /**
+   * Return the value if it is a non-empty array, otherwise the fallback.
+   * Guards against the "empty array is truthy" footgun where `value || fallback`
+   * keeps an empty `[]` instead of using the fallback.
+   * @param {*} value - The candidate array
+   * @param {*} fallback - Returned when value is not a non-empty array
+   * @returns {*} value when it is a non-empty array, otherwise fallback
+   * @example
+   * NativeUtils.coalesceArray(['a'], ['x']); // ['a']
+   * NativeUtils.coalesceArray([], ['x']);    // ['x']
+   * NativeUtils.coalesceArray(undefined, ['x']); // ['x']
+   */
+  coalesceArray: function(value, fallback) {
+    return (Array.isArray(value) && value.length) ? value : fallback;
   }
 };


### PR DESCRIPTION
## Summary
With "I want the detail view to auto update when new fields are added" enabled, the detail-view merge re-added **any** data source column missing from `detailViewOptions` — including columns the user had intentionally removed. Deleted fields therefore reappeared when the Data View Settings overlay was re-opened, and re-rendered in preview at runtime.

Fix tracks a `detailViewKnownColumns` snapshot (the DS column set as of the last save) and only auto-adds columns that are **not** in it. Intentionally-removed columns remain in the snapshot, so they are treated as "known" and never re-added; genuinely new columns (absent from both the saved options and the snapshot) still appear. Existing configs with no snapshot seed it from the current columns, so previously-deleted fields are not re-added.

Fixes [PS-1879](https://weboo.atlassian.net/browse/PS-1879)

## Acceptance criteria
- [x] Checkbox ON: deleting fields + Save & Close → fields stay gone on re-open — `js/interface.js` `knownColumns` gate
- [x] Checkbox ON: deleted fields do not re-render in preview — all 5 runtime layouts gate `extraColumns` on `knownColumns`
- [x] Genuinely new DS columns still auto-appear — new columns are in neither `savedColumns` nor `knownColumns`
- [x] Checkbox OFF: deletions persist (unchanged) — changes live inside the existing `if (detailViewAutoUpdate)` blocks
- [x] Existing apps without a snapshot don't re-add deleted fields — seed `|| dataSourceColumns`

## Test plan
- [ ] App **454728 / page 1936384** (QA repro), checkbox ON: delete Buttons/Order/Popular → Save & Close → reopen Data View tab → fields stay deleted; preview omits them
- [ ] Add a new column to the data source → confirm it auto-appears (feature preserved)
- [ ] Checkbox OFF → deletions persist (no regression)
- [ ] Spot-check across layouts (news-feed, simple-list, small-card, small-h-card, agenda)

## Verification (automated)
- Tests: 72 passed, 0 failed (`npx jest`)
- Lint: no new errors/warnings (2 parsing errors + `no-console` warnings are pre-existing on master)
- Changed: `js/interface.js` + 5 runtime layout files — all `detailViewAutoUpdate` merge sites gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1879]: https://weboo.atlassian.net/browse/PS-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ